### PR TITLE
fix: k8s installation doc was having wrong url in install.md

### DIFF
--- a/src/pages/en/install.md
+++ b/src/pages/en/install.md
@@ -31,11 +31,11 @@ helm uninstall kubeshark
 Each release includes a complete K8s manifest that can be customized or used as is:  
 ```shell  
 export TAG=v52.3.92  # as an example
-kubectl apply -f https://raw.githubusercontent.com/kubeshark/kubeshark/refs/$TAG/manifests/complete.yaml  
+kubectl apply -f https://raw.githubusercontent.com/kubeshark/kubeshark/refs/tags/$TAG/manifests/complete.yaml  
 kubectl port-forward service/kubeshark-front 8899:80  
 
 # cleanup  
-kubectl delete -f https://raw.githubusercontent.com/kubeshark/kubeshark/refs/$TAG/manifests/complete.yaml  
+kubectl delete -f https://raw.githubusercontent.com/kubeshark/kubeshark/refs/tags/$TAG/manifests/complete.yaml  
 ```  
 
 You can choose a `tag` from: https://github.com/kubeshark/kubeshark/tags.  


### PR DESCRIPTION
It is mentioned in the doc to install Kubeshark using k8s manifest but the url provided is incorrect.

- **wrong url:** kubectl apply -f https://raw.githubusercontent.com/kubeshark/kubeshark/refs/$TAG/manifests/complete.yaml
- **correct should have `tags` in it:** kubectl apply -f https://raw.githubusercontent.com/kubeshark/kubeshark/refs/tags/$TAG/manifests/complete.yaml 