### PR TITLE
Document 2GB snapshot size limitation

### DIFF
--- a/src/pages/en/dashboard_snapshots.md
+++ b/src/pages/en/dashboard_snapshots.md
@@ -24,6 +24,7 @@ The snapshot is extracted from [Raw Capture](/en/v2/raw_capture) buffers and mov
 | Constraint | Description |
 |------------|-------------|
 | Maximum window | Limited by raw capture buffer size and traffic rate |
+| Maximum size   | 2 GB per snapshot. Reduce by selecting fewer nodes or a shorter time window. |
 | Availability | Data must not have been recycled from raw capture |
 
 ---

--- a/src/pages/en/mcp/raw_capture_tools.md
+++ b/src/pages/en/mcp/raw_capture_tools.md
@@ -104,6 +104,8 @@ Create a new snapshot.
 | `name` | string | Unique snapshot identifier |
 | `duration` | string | Time duration to capture (e.g., `30m`, `1h`, `2h`) |
 
+> **Note:** Snapshots are limited to 2 GB. To stay within this limit, use shorter durations or target specific nodes.
+
 **Response:**
 ```json
 {

--- a/src/pages/en/v2/traffic_snapshots.md
+++ b/src/pages/en/v2/traffic_snapshots.md
@@ -17,6 +17,7 @@ When you create a snapshot, you specify how far back to capture—last 5 minutes
 | Constraint | Description |
 |------------|-------------|
 | Maximum window | Limited by raw capture retention (buffer size / traffic rate) |
+| Maximum size   | 2 GB per snapshot. Control size by selecting fewer nodes or narrowing the time window. |
 | Storage | Snapshots persist until explicitly deleted |
 
 ### Dedicated Snapshot Storage


### PR DESCRIPTION
## Summary

- Add **Maximum size** (2 GB per snapshot) row to the constraints table in the traffic snapshots overview page
- Add **Maximum size** row to the constraints table in the dashboard snapshots guide
- Add a callout note about the 2 GB limit in the MCP raw capture tools reference (POST `/mcp/snapshots` section)

Each entry explains how to stay within the limit by selecting fewer nodes or using a shorter time window. This limit applies only to individual snapshots — raw capture itself is not affected.

## Test plan

- [ ] Verify the three modified pages render correctly with `npm start`
- [ ] Confirm constraint tables display properly with the new row