### PR TITLE
Refresh documentation theme and visual styling

### DIFF
--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -16,11 +16,9 @@ import '../styles/index.css';
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-	href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital@0;1&display=swap"
+	href="https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&family=Ubuntu+Mono:wght@400;700&display=swap"
 	rel="stylesheet"
 />
-
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Work+Sans:400,300,500,700,900,800,600">
 
 <!-- Scrollable a11y code helper -->
 <script src="/make-scrollable-code-focusable.js" is:inline>

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -55,14 +55,14 @@ const sidebar = SIDEBAR[langCode];
 
 	.nav-groups {
 		height: 100%;
-		padding: 2rem 0;
+		padding: 1.5rem 0;
 		overflow-x: visible;
 		overflow-y: auto;
 		max-height: 100vh;
 	}
 
 	.nav-groups > li + li {
-		margin-top: 2rem;
+		margin-top: 1rem;
 	}
 
 	.nav-groups > :first-child {
@@ -74,26 +74,36 @@ const sidebar = SIDEBAR[langCode];
 		margin-bottom: var(--theme-navbar-height);
 	}
 
-	.nav-group-title {
-		font-size: 1rem;
+	.nav-group h2 {
+		font-size: 0.8rem;
 		font-weight: 700;
-		padding: 0.1rem 1rem;
+		padding: 0.5rem 1rem 0.35rem;
 		text-transform: uppercase;
-		margin-bottom: 0.5rem;
+		letter-spacing: 0.05em;
+		color: var(--theme-text);
+		margin-bottom: 0.15rem;
+		border-bottom: 1px solid var(--theme-divider);
+		margin-left: 0.5rem;
+		margin-right: 0.5rem;
+		padding-left: 0.5rem;
+		cursor: default;
 	}
 
 	.nav-link a {
-		font-size: 1rem;
-		margin: 1px;
-		padding: 0.3rem 1rem;
+		font-size: 0.9rem;
+		margin: 0;
+		padding: 0.35rem 1rem;
 		font: inherit;
-		color: inherit;
+		color: var(--theme-text-light);
 		text-decoration: none;
 		display: block;
+		border-radius: 6px;
+		transition: all 0.15s ease;
 	}
 
 	.nav-link a:hover,
 	.nav-link a:focus {
+		color: var(--theme-text);
 		background-color: var(--theme-bg-hover);
 	}
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -107,7 +107,7 @@ p {
 
 p,
 .content ul {
-	color: var(--theme-text-light);
+	color: var(--theme-text);
 }
 
 small,

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -25,9 +25,11 @@ body {
 	min-height: 100vh;
 	font-family: var(--font-body);
 	font-size: 1rem;
-	font-size: clamp(0.9rem, 0.75rem + 0.375vw + var(--user-font-scale), 1rem);
-	line-height: 1.5;
+	font-size: clamp(0.95rem, 0.85rem + 0.25vw + var(--user-font-scale), 1.05rem);
+	line-height: 1.7;
 	max-width: 100vw;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 nav ul {
@@ -51,8 +53,10 @@ h4,
 h5,
 h6 {
 	margin-bottom: 1rem;
-	font-weight: bold;
-	line-height: 1;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--theme-text);
+	letter-spacing: -0.02em;
 }
 
 h1,
@@ -61,20 +65,23 @@ h2 {
 }
 
 :is(h2, h3):not(:first-child) {
-	margin-top: rem;
+	margin-top: 2.5rem;
 }
 
 :is(h4, h5, h6):not(:first-child) {
-	margin-top: 1.5rem;
+	margin-top: 2rem;
 }
 
 h1 {
-	font-size: 2.25rem;
-	font-weight: 800;
+	font-size: 2rem;
+	font-weight: 700;
+	letter-spacing: -0.02em;
+	line-height: 1.2;
 }
 
 h2 {
-	font-size: 1.75rem;
+	font-size: 1.875rem;
+	font-weight: 600;
 }
 
 h3 {
@@ -86,11 +93,12 @@ h4 {
 }
 
 h5 {
-	font-size: 1rem;
+	font-size: 1.1rem;
 }
 
 p {
-	line-height: 1.65em;
+	line-height: 1.75;
+	margin-bottom: 1.25rem;
 }
 
 .content ul {
@@ -109,10 +117,14 @@ small,
 
 a {
 	color: var(--theme-text-accent);
-	font-weight: 400;
-	text-underline-offset: 0.08em;
-	align-items: center;
-	gap: 0.5rem;
+	font-weight: 500;
+	text-decoration: none;
+	text-underline-offset: 0.15em;
+	transition: color 0.15s ease;
+}
+
+a:hover {
+	color: var(--theme-accent-hover, var(--theme-accent));
 }
 
 article > section :is(ul, ol) > * + * {
@@ -189,96 +201,106 @@ strong {
 /* Supporting Content */
 
 code {
-	--border-radius: 3px;
-	--padding-block: 0.2rem;
-	--padding-inline: 0rem;
-
 	font-family: var(--font-mono);
-	font-size: 0.85em;
-	color: inherit;
+	font-size: 0.875em;
+	color: var(--theme-code-inline-text);
 	background-color: var(--theme-code-inline-bg);
-	padding: var(--padding-block) var(--padding-inline);
-	margin: calc(var(--padding-block) * -1) -0.125em;
-	border-radius: var(--border-radius);
+	padding: 0.2em 0.4em;
+	border-radius: 6px;
 	word-break: break-word;
-
-  margin: 1px;
-  padding: 3px 5px 3px 5px;
+	font-weight: 400;
+	letter-spacing: 0.02rem;
 }
 
 pre.astro-code > code {
 	all: unset;
+	font-weight: normal;
 }
 
 pre > code {
-	font-size: 1em;
-
-  margin: 0px;
-  padding: 0px;
+	font-size: inherit;
+	margin: 0;
+	padding: 0;
+	font-weight: 400;
+	letter-spacing: inherit;
 }
 
-table,
 pre {
 	position: relative;
-	--padding-block: 1rem;
-	--padding-inline: 2rem;
-	padding: var(--padding-block) var(--padding-inline);
-	padding-right: calc(var(--padding-inline) * 2);
-	margin-left: calc(var(--padding-inline) * -1);
-	margin-right: calc(var(--padding-inline) * -1);
+	padding: 1em 4em 1em 1em;
+	margin: 1.5rem 0;
 	font-family: var(--font-mono);
-
-	line-height: 1.5;
-	font-size: 0.85em;
-	overflow-y: hidden;
+	line-height: 26px;
+	font-size: 0.875rem;
+	letter-spacing: 0.02rem;
 	overflow-x: auto;
+	background-color: var(--theme-code-bg);
+	color: var(--theme-code-text);
+	border-radius: 8px;
+	border: none;
 }
 
 table {
 	width: 100%;
-	padding: var(--padding-block) 0;
-	margin: 0;
-	border-collapse: collapse;
+	margin: 1.5rem 0;
+	border-collapse: separate;
+	border-spacing: 0;
+	font-size: 0.925rem;
+	border-radius: var(--theme-border-radius, 8px);
+	overflow: hidden;
+	border: 1px solid var(--theme-divider);
 }
 
-/* Zebra striping */
-tr:nth-of-type(odd) {
+thead {
+	background: var(--theme-bg-offset);
+}
+
+th {
+	font-weight: 600;
+	text-align: left;
+	padding: 0.875rem 1rem;
+	color: var(--theme-text);
+	font-size: 0.8rem;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	border-bottom: 1px solid var(--theme-divider);
+}
+
+td {
+	padding: 0.875rem 1rem;
+	border-bottom: 1px solid var(--theme-divider);
+	color: var(--theme-text-light);
+}
+
+tr:last-child td {
+	border-bottom: none;
+}
+
+/* Subtle hover on rows */
+tbody tr:hover {
 	background: var(--theme-bg-hover);
 }
-th {
-	background: var(--color-black);
-	color: var(--theme-color);
-	font-weight: bold;
-}
-td,
-th {
-	padding: 6px;
-	text-align: left;
-}
 
-pre {
-	background-color: var(--theme-code-bg);
-	color: var(--theme-code-text);
+/* Remove zebra striping - cleaner look */
+tr:nth-of-type(odd) {
+	background: transparent;
 }
 
 blockquote code {
 	background-color: var(--theme-bg);
 }
 
-pre {
-	--padding-inline: 1.25rem;
-	border-radius: 8px;
-	margin-left: 0;
-	margin-right: 0;
+blockquote {
+	margin: 1.5rem 0;
+	padding: 1rem 1.5rem;
+	border-left: 3px solid var(--theme-accent);
+	background-color: var(--theme-bg-offset);
+	border-radius: 0 var(--theme-border-radius, 8px) var(--theme-border-radius, 8px) 0;
+	line-height: 1.7;
 }
 
-blockquote {
-	margin: 2rem 0;
-	padding: 1.25em 1.5rem;
-	border-left: 3px solid var(--theme-text-light);
-	background-color: var(--theme-bg-offset);
-	border-radius: 0 0.25rem 0.25rem 0;
-	line-height: 1.7;
+blockquote p {
+	margin-bottom: 0;
 }
 
 img {
@@ -383,4 +405,204 @@ h2.heading {
 
 :target {
 	scroll-margin: calc(var(--theme-sidebar-offset, 5rem) + 2rem) 0 2rem;
+}
+
+/* ============================================
+   Knowledge Base Styling - Callouts & Cards
+   ============================================ */
+
+/* Callout / Admonition Boxes */
+.callout {
+	margin: 1.5rem 0;
+	padding: 1rem 1.25rem;
+	border-radius: 0.5rem;
+	border-left: 4px solid;
+}
+
+.callout p {
+	margin: 0;
+	color: var(--theme-text);
+}
+
+.callout p + p {
+	margin-top: 0.75rem;
+}
+
+.callout-info {
+	background-color: hsla(var(--color-blue), 0.1);
+	border-left-color: hsla(var(--color-blue), 1);
+}
+
+.callout-tip {
+	background-color: hsla(var(--color-green), 0.1);
+	border-left-color: hsla(var(--color-green), 1);
+}
+
+.callout-warning {
+	background-color: hsla(var(--color-orange), 0.15);
+	border-left-color: hsla(var(--color-orange), 1);
+}
+
+.callout-danger {
+	background-color: hsla(var(--color-red), 0.1);
+	border-left-color: hsla(var(--color-red), 1);
+}
+
+.theme-dark .callout-info {
+	background-color: hsla(var(--color-blue), 0.15);
+}
+
+.theme-dark .callout-tip {
+	background-color: hsla(var(--color-green), 0.15);
+}
+
+.theme-dark .callout-warning {
+	background-color: hsla(var(--color-orange), 0.2);
+}
+
+.theme-dark .callout-danger {
+	background-color: hsla(var(--color-red), 0.15);
+}
+
+/* Feature Grid for Introduction Page */
+.feature-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 1.5rem;
+	margin: 1.5rem 0;
+}
+
+@media (min-width: 50em) {
+	.feature-grid {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
+.feature-grid h3 {
+	font-size: 1.1rem;
+	margin-bottom: 0.5rem;
+	color: var(--theme-text);
+}
+
+.feature-grid p {
+	font-size: 0.95rem;
+	margin: 0;
+}
+
+/* Version Badge */
+.badge {
+	display: inline-block;
+	padding: 0.2em 0.6em;
+	font-size: 0.75rem;
+	font-weight: 600;
+	border-radius: 0.25rem;
+	text-transform: uppercase;
+	letter-spacing: 0.02em;
+}
+
+.badge-new {
+	background-color: hsla(var(--color-green), 0.2);
+	color: hsla(var(--color-green), 1);
+}
+
+.badge-v2 {
+	background-color: hsla(var(--color-blue), 0.2);
+	color: hsla(var(--color-blue), 1);
+}
+
+.badge-pro {
+	background-color: hsla(var(--color-purple), 0.2);
+	color: hsla(var(--color-purple), 1);
+}
+
+.badge-deprecated {
+	background-color: hsla(var(--color-orange), 0.2);
+	color: hsla(var(--color-orange), 1);
+}
+
+/* Breadcrumb Styling */
+.breadcrumb {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 0.875rem;
+	color: var(--theme-text-light);
+	margin-bottom: 1rem;
+	flex-wrap: wrap;
+}
+
+.breadcrumb a {
+	color: var(--theme-text-light);
+	text-decoration: none;
+}
+
+.breadcrumb a:hover {
+	color: var(--theme-text-accent);
+	text-decoration: underline;
+}
+
+.breadcrumb-separator {
+	color: var(--theme-text-light);
+	opacity: 0.5;
+}
+
+.breadcrumb-current {
+	color: var(--theme-text);
+	font-weight: 500;
+}
+
+/* Enhanced Table Styling */
+table {
+	font-family: var(--font-body);
+}
+
+th {
+	background: var(--theme-bg-offset);
+	color: var(--theme-text);
+	font-size: 0.875rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+}
+
+td, th {
+	border-bottom: 1px solid var(--theme-divider);
+}
+
+/* Quick Start Box */
+.quick-start {
+	background: var(--theme-bg-offset);
+	border-radius: 0.5rem;
+	padding: 1.5rem;
+	margin: 1.5rem 0;
+}
+
+.quick-start h2, .quick-start h3 {
+	margin-top: 0;
+}
+
+/* Next Steps / Related Links */
+.next-steps {
+	margin-top: 2rem;
+	padding-top: 1.5rem;
+	border-top: 1px solid var(--theme-divider);
+}
+
+.next-steps ul {
+	list-style: none;
+	padding: 0;
+}
+
+.next-steps li {
+	padding: 0.5rem 0;
+	border-bottom: 1px solid var(--theme-divider);
+}
+
+.next-steps li:last-child {
+	border-bottom: none;
+}
+
+.next-steps a {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,10 +1,8 @@
 :root {
-	--font-fallback: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
+	--font-fallback: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
 		Apple Color Emoji, Segoe UI Emoji;
-	--font-body: system-ui, var(--font-fallback);
-	--font-mono: "Fira Code", monospace, 'IBM Plex Mono', Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console',
-		'Lucida Sans Typewriter', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Liberation Mono',
-		'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace;
+	--font-body: 'Ubuntu', Helvetica, sans-serif, var(--font-fallback);
+	--font-mono: 'Ubuntu Mono', 'Fira Code', 'SF Mono', Menlo, Consolas, monospace;
 
 	/*
    * Variables with --color-base prefix define
@@ -59,26 +57,29 @@
 :root {
 	color-scheme: light;
 	--theme-accent: #326de6;
+	--theme-accent-hover: #2756b8;
 	--theme-text-accent: var(--theme-accent);
-	--theme-accent-opacity: 0.15;
-	--theme-divider: hsla(var(--color-gray-95), 1);
-	--theme-text: hsla(var(--color-gray-10), 1);
-	--theme-text-light: hsla(var(--color-gray-40), 1);
-	/* @@@: not used anywhere */
-	--theme-text-lighter: hsla(var(--color-gray-80), 1);
-	--theme-bg: hsla(var(--color-base-white), 100%, 1);
-	--theme-bg-hover: hsla(var(--color-gray-95), 1);
-	--theme-bg-offset: hsla(var(--color-gray-90), 1);
-	--theme-bg-accent: hsla(var(--color-blue), var(--theme-accent-opacity));
-	--theme-code-inline-bg: hsla(var(--color-gray-95), 1);
-	--theme-code-inline-text: var(--theme-text);
-	--theme-code-bg: hsla(var(--color-gray-20), 1);
-	--theme-code-text: hsla(var(--color-gray-95), 1);
-  --theme-code-copied: #5888e8;
-	--theme-navbar-bg: hsla(var(--color-base-white), 100%, 1);
-	--theme-navbar-height: 6rem;
-	--theme-selection-color: var(--theme-accent);
-	--theme-selection-bg: hsla(var(--color-blue), var(--theme-accent-opacity));
+	--theme-accent-opacity: 0.1;
+	--theme-divider: #e5e7eb;
+	--theme-text: #1f2937;
+	--theme-text-light: #6b7280;
+	--theme-text-lighter: #9ca3af;
+	--theme-bg: #ffffff;
+	--theme-bg-hover: #f9fafb;
+	--theme-bg-offset: #f3f4f6;
+	--theme-bg-accent: rgba(50, 109, 230, 0.08);
+	--theme-code-inline-bg: #f1f5f9;
+	--theme-code-inline-text: #0f172a;
+	--theme-code-bg: #0c0b1a;
+	--theme-code-text: #a0b2ff;
+	--theme-code-copied: #5888e8;
+	--theme-navbar-bg: rgba(255, 255, 255, 0.9);
+	--theme-navbar-height: 4rem;
+	--theme-selection-color: #ffffff;
+	--theme-selection-bg: var(--theme-accent);
+	--theme-border-radius: 8px;
+	--theme-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+	--theme-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
 }
 
 body {
@@ -88,37 +89,39 @@ body {
 
 :root.theme-dark {
 	color-scheme: dark;
-	--theme-accent-opacity: 0.15;
-	--theme-accent: #326de6;
+	--theme-accent: #5b8def;
+	--theme-accent-hover: #7ba3f3;
 	--theme-text-accent: var(--theme-accent);
-	--theme-divider: hsla(var(--color-gray-10), 1);
-	--theme-text: hsla(var(--color-gray-90), 1);
-	--theme-text-light: hsla(var(--color-gray-80), 1);
-
-	/* @@@: not used anywhere */
-	--theme-text-lighter: hsla(var(--color-gray-40), 1);
-	--theme-bg: hsla(215, 28%, 17%, 1);
-	--theme-bg-hover: hsla(var(--color-gray-40), 1);
-	--theme-bg-offset: hsla(var(--color-gray-5), 1);
-	--theme-code-inline-bg: hsla(var(--color-gray-10), 1);
-	--theme-code-inline-text: hsla(var(--color-base-white), 100%, 1);
-	--theme-code-bg: hsla(var(--color-gray-5), 1);
-	--theme-code-text: hsla(var(--color-base-white), 100%, 1);
-  --theme-code-copied: var(--theme-accent);
-	--theme-navbar-bg: var(--theme-bg);
-	--theme-selection-color: hsla(var(--color-base-white), 100%, 1);
-	--theme-selection-bg: hsla(var(--color-purple), var(--theme-accent-opacity));
+	--theme-accent-opacity: 0.15;
+	--theme-divider: #374151;
+	--theme-text: #f3f4f6;
+	--theme-text-light: #9ca3af;
+	--theme-text-lighter: #6b7280;
+	--theme-bg: #111827;
+	--theme-bg-hover: #1f2937;
+	--theme-bg-offset: #1f2937;
+	--theme-bg-accent: rgba(91, 141, 239, 0.15);
+	--theme-code-inline-bg: #1e293b;
+	--theme-code-inline-text: #a0b2ff;
+	--theme-code-bg: #0c0b1a;
+	--theme-code-text: #a0b2ff;
+	--theme-code-copied: var(--theme-accent);
+	--theme-navbar-bg: rgba(17, 24, 39, 0.9);
+	--theme-selection-color: #ffffff;
+	--theme-selection-bg: var(--theme-accent);
+	--theme-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+	--theme-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4), 0 1px 2px -1px rgba(0, 0, 0, 0.3);
 
 	/* DocSearch [Algolia] */
 	--docsearch-modal-background: var(--theme-bg);
-	--docsearch-searchbox-focus-background: var(--theme-divider);
-	--docsearch-footer-background: var(--theme-divider);
+	--docsearch-searchbox-focus-background: var(--theme-bg-offset);
+	--docsearch-footer-background: var(--theme-bg-offset);
 	--docsearch-text-color: var(--theme-text);
-	--docsearch-hit-background: var(--theme-divider);
+	--docsearch-hit-background: var(--theme-bg-offset);
 	--docsearch-hit-shadow: none;
 	--docsearch-hit-color: var(--theme-text);
-	--docsearch-footer-shadow: inset 0 2px 10px #000;
-	--docsearch-modal-shadow: inset 0 0 8px #000;
+	--docsearch-footer-shadow: none;
+	--docsearch-modal-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
 }
 
 ::selection {


### PR DESCRIPTION
## Summary

- **Typography**: Switch from system/Work Sans fonts to Ubuntu font family for a cleaner, more consistent look across the documentation
- **Color palette**: Modernize light and dark theme variables with refined grays, improved contrast, and softer accent colors
- **Component styling**: Redesign tables (remove zebra striping, add subtle hover), code blocks (new dark bg with tinted text), blockquotes (accent border), and sidebar navigation (smaller text, section dividers, rounded hover states)
- **New CSS utilities**: Add callout/admonition boxes (info, tip, warning, danger), feature grid, version badges, breadcrumbs, quick-start box, and next-steps components for richer documentation pages

## Test plan

- [ ] Verify light and dark theme rendering across all page types
- [ ] Check sidebar navigation styling and hover states
- [ ] Confirm code blocks, tables, and blockquotes render correctly
- [ ] Test responsive layout on mobile viewports
- [ ] Validate font loading (Ubuntu + Ubuntu Mono from Google Fonts)