### PR TITLE
docs: weekly update for 2026-W17

### DIFF
--- a/src/pages/en/v2/kfl2.md
+++ b/src/pages/en/v2/kfl2.md
@@ -35,6 +35,9 @@ dns && "google.com" in dns_questions
 # Large HTTP responses
 http && response_body_size > 10000
 
+# Failed gRPC calls
+grpc && grpc_status != 0
+
 # Slow requests (over 5 seconds)
 http && elapsed_time > 5000000
 
@@ -161,9 +164,9 @@ Boolean variables that indicate which protocol was detected. Use these as the fi
 | `udp` | UDP | `ws` | WebSocket |
 | `sctp` | SCTP | `gql` | GraphQL (v1 + v2) |
 | `icmp` | ICMP | `gqlv1` / `gqlv2` | GraphQL version-specific |
-| `radius` | RADIUS | `conn` / `flow` | L4 connection/flow tracking |
-| `diameter` | Diameter | `tcp_conn` / `udp_conn` | Transport-specific connections |
-| | | `tcp_flow` / `udp_flow` | Transport-specific flows |
+| `grpc` | gRPC over HTTP/2 | `conn` / `flow` | L4 connection/flow tracking |
+| `radius` | RADIUS | `tcp_conn` / `udp_conn` | Transport-specific connections |
+| `diameter` | Diameter | `tcp_flow` / `udp_flow` | Transport-specific flows |
 
 ### Identity and Metadata Variables
 
@@ -213,6 +216,15 @@ Boolean variables that indicate which protocol was detected. Use these as the fi
 | `response_body_size` | int | Response body size in bytes |
 
 GraphQL requests have `gql` (or `gqlv1`/`gqlv2`) set to true and all HTTP variables available.
+
+### gRPC Variables
+
+gRPC traffic is detected as a sub-protocol of HTTP/2. When `grpc` is true, all HTTP variables are also available.
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `grpc_method` | string | gRPC method name extracted from the `:path` trailing segment (e.g. `/helloworld.Greeter/SayHello` → `SayHello`) |
+| `grpc_status` | int | gRPC status code from the `Grpc-Status` response header/trailer (defaults to `0` / OK when absent) |
 
 ### DNS Variables
 
@@ -492,6 +504,25 @@ dns && "A" in dns_question_types
 
 # DNS responses with answers
 dns && dns_response && size(dns_answers) > 0
+```
+
+### gRPC Filtering
+
+```cel
+# All gRPC traffic
+grpc
+
+# Filter by gRPC method name
+grpc && grpc_method == "SayHello"
+
+# Failed gRPC calls (non-OK status)
+grpc && grpc_status != 0
+
+# Specific gRPC status code (e.g. 5 = NOT_FOUND)
+grpc && grpc_status == 5
+
+# Combine with HTTP variables
+grpc && method == "POST" && status_code == 200
 ```
 
 ### DNS Resolution Filtering


### PR DESCRIPTION
Weekly documentation update covering merged PRs from 2026-04-20T06:29:57Z through now.

## Source PRs

### kubeshark/hub

- [#739 Skip incomplete dissections from upload to cloud](https://github.com/kubeshark/hub/pull/739) — @corest
- [#729 Update grpc in e2e tests to address dependabot issues](https://github.com/kubeshark/hub/pull/729) — @corest
- [#728 Update dependencies to fix docker scout issues](https://github.com/kubeshark/hub/pull/728) — @corest
- [#726 Document grpc, grpc_method, grpc_status in MCP KFL schema](https://github.com/kubeshark/hub/pull/726) — @iluxa
- [#725 Add mcp api call counter to telemetry](https://github.com/kubeshark/hub/pull/725) — @corest
- [#724 Rename snapshot in cloud on rename local](https://github.com/kubeshark/hub/pull/724) — @corest
- [#722 Stream history implementation](https://github.com/kubeshark/hub/pull/722) — @iluxa

### kubeshark/worker

- [#1125 Drop arm64 race builds due to toolchain limitations](https://github.com/kubeshark/worker/pull/1125) — @corest
- [#1124 Update registry offsets](https://github.com/kubeshark/worker/pull/1124) — @alongir
- [#1118 Update spdystream to address cves](https://github.com/kubeshark/worker/pull/1118) — @corest
- [#1117 Bump deps to close Scout CVEs (moby v2, go-jose, jsonparser, otel)](https://github.com/kubeshark/worker/pull/1117) — @corest
- [#1116 Update go to 1.26.2](https://github.com/kubeshark/worker/pull/1116) — @corest
- [#1114 Fix request response matcher in mongodb and kafks; Fix pebble use after close; Reduce failaed parse packet log message](https://github.com/kubeshark/worker/pull/1114) — @iluxa
- [#1112 Add grpc, grpc_method, grpc_status KFL variables](https://github.com/kubeshark/worker/pull/1112) — @iluxa
- [#1110 Stream history implementation](https://github.com/kubeshark/worker/pull/1110) — @iluxa
- [#1106 gotls: Go TLS decryption for wrapped connections (Traefik)](https://github.com/kubeshark/worker/pull/1106) — @alongir

### kubeshark/front

- [#1192 :bug: Fix re-running dissection on failure](https://github.com/kubeshark/front/pull/1192) — @tiptophelmet
- [#1180 Updates build env to new version](https://github.com/kubeshark/front/pull/1180) — @corest
- [#1179 :sparkles: Create copy button for snapshot failure reason](https://github.com/kubeshark/front/pull/1179) — @tiptophelmet
- [#1178 :lipstick: Show both entry namespaces by default](https://github.com/kubeshark/front/pull/1178) — @tiptophelmet
- [#1174 :sparkles: Surface grpc_method / grpc_status as KFL queries in UI](https://github.com/kubeshark/front/pull/1174) — @iluxa
- [#1173 Stream history implementation](https://github.com/kubeshark/front/pull/1173) — @iluxa
- [#1161 :zap: Columnar Entry Storage: 4× Heap Memory Reduction](https://github.com/kubeshark/front/pull/1161) — @tiptophelmet

### kubeshark/kfl2

- [#23 Add grpc, grpc_method, grpc_status KFL variables](https://github.com/kubeshark/kfl2/pull/23) — @iluxa

### kubeshark/api2

- [#83 Stream history implementation](https://github.com/kubeshark/api2/pull/83) — @iluxa

