### PR TITLE
Update Pro pricing to single PRO-201 plan

### DIFF
--- a/src/pages/en/plans.md
+++ b/src/pages/en/plans.md
@@ -13,27 +13,17 @@ The Community edition is designed for small workloads:
 - Requires internet connectivity
 - Community support
 
-## Pro (Starting at $20/month)
+## Pro ($200/month)
 
-The Pro edition offers volume-based pricing for any cluster size. Choose a tier based on your usage needs:
+The Pro edition offers a simple, all-inclusive plan for any cluster size:
 
-| Tier | Monthly Price | Daily API Capacity | Monthly Capacity |
-|------|---------------|-------------------|------------------|
-| Pro 100K | $20 | 100K API calls | ~3M API calls |
-| Pro 700K | $100 | 700K API calls | ~21M API calls |
-| Pro 2M | $200 | 2M API calls | ~60M API calls |
-
-> The $200 tier provides 20x the capacity of the $20 tier at only 10x the price.
-
-**Key features:**
-- **Unlimited** cluster size and pods on all tiers
+- **$200/month** with **100K API calls** included
+- **Unlimited** cluster size and pods
 - **Cluster-wide license** — download a license key from the [License Portal](https://console.kubeshark.com) and all users in the cluster can access Kubeshark without individual authentication
 - Use across **any number of clusters**
 - No cloud login required — license key based
 - Requires active internet connectivity (telemetry must succeed)
 - Community support
-
-**On-demand capacity:** Additional capacity can be purchased at **$5 per 100K API calls** when you exceed your daily limit.
 
 > API capacity is measured in dissected API calls that appear in the dashboard.
 

--- a/src/pages/en/pro.md
+++ b/src/pages/en/pro.md
@@ -10,13 +10,13 @@ The Community edition is offered at no cost and supports clusters of up to 4 nod
 
 > To get started with the Community edition, [install **Kubeshark**](/en/install).
 
-## Pro
+## Pro ($200/month)
 
-Volume-based pricing for any cluster size. Download a license key from the [License Portal](https://console.kubeshark.com) for cluster-wide, multi-user access — no cloud login required.
+A single plan at **$200/month** with **100K API calls** included — for any cluster size. Download a license key from the [License Portal](https://console.kubeshark.com) for cluster-wide, multi-user access — no cloud login required.
 
 Pro licenses require an active internet connection (telemetry must succeed).
 
-See [Plans](/en/plans) for pricing tiers.
+See [Plans](/en/plans) for details.
 
 ## Enterprise
 


### PR DESCRIPTION
## Summary
- Replace the three Pro pricing tiers (Pro 100K/$20, Pro 700K/$100, Pro 2M/$200) with a single PRO-201 plan at $200/month with 100K API calls
- Updated `plans.md` and `pro.md` to reflect the new single-plan pricing model
- Removes on-demand capacity pricing and tier comparison table

Refs kubeshark/console-v3#145