### PR TITLE
Docs: unified AUTH_ROLES + AUTH_TYPE label cleanup

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -82,7 +82,7 @@ export const SIDEBAR: Sidebar = {
       { text: 'Cloud Storage for Snapshots', link: 'en/snapshots_cloud_storage' },
       { text: 'Workload Resources', link: 'en/workload_resources' },
       { text: 'SAML', link: 'en/saml' },
-      { text: 'OIDC w/ DEX', link: 'en/oidc' },
+      { text: 'OIDC', link: 'en/oidc' },
       { text: 'Reverse Proxy w/ Custom Path', link: 'en/custom_path' },
       { text: 'EFS Persistent Volume', link: 'en/efs' },
       { text: 'Node Scheduling', link: 'en/node_scheduling' },

--- a/src/pages/en/helm_reference.md
+++ b/src/pages/en/helm_reference.md
@@ -210,12 +210,15 @@ The `roles` map is shared by both SAML and OIDC backends — admins maintain a s
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `tap.auth.roles` | Role-name → permission map. See [SAML](/en/saml) or [OIDC](/en/oidc) for the per-role schema. | `{}` |
+| `tap.auth.roles` | Role-name → permission map. Each role carries action flags plus `namespaces` (comma list controlling traffic visibility — `""` deny, `"*"` allow-all, `"foo"` literal, `"foo,bar"` OR, `"foo-*"` glob expansion against the cluster's watched namespaces). See [SAML](/en/saml) or [OIDC](/en/oidc) for the full per-role schema. | `{}` |
 | `tap.auth.rolesClaim` | JWT claim name (OIDC) or SAML attribute name carrying the user's role memberships | `role` (SAML) / `groups` (OIDC) |
 | `tap.auth.defaultRole` | Name of a role inside `tap.auth.roles` applied when an authenticated user has no matching role in their token/assertion. Empty string means no fallback (authenticated but no elevated permissions). | `""` |
-| `tap.auth.defaultFilter` | KFL filter substituted in for any role whose `filter` is empty. Set to `1==0` to opt the deployment into data-level deny-default. Empty string preserves legacy allow-all-on-blank. | `""` |
 
-> **Breaking change since the unified rollout:** empty/unset `tap.auth.roles` no longer grants all permissions — it grants none. Set `tap.auth.defaultRole` to keep a "every authenticated user gets X" baseline. Legacy `tap.auth.saml.roles` and `tap.auth.saml.roleAttribute` are no longer read; migrate to the top-level keys above.
+> **Breaking changes since the unified rollout:**
+> - Empty/unset `tap.auth.roles` no longer grants all permissions — it grants none. Set `tap.auth.defaultRole` to keep a "every authenticated user gets X" baseline.
+> - Per-role `filter` (raw KFL string) was replaced with `namespaces` (comma list). Configs carrying `filter:` are silently ignored; migrate.
+> - `tap.auth.defaultFilter` is removed; `namespaces: ""` is the explicit per-role deny-default.
+> - Legacy `tap.auth.saml.roles` and `tap.auth.saml.roleAttribute` are no longer read; migrate to the top-level keys above.
 
 ### SAML
 

--- a/src/pages/en/helm_reference.md
+++ b/src/pages/en/helm_reference.md
@@ -200,30 +200,43 @@ Complete reference for Kubeshark Helm configuration values.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `tap.auth.enabled` | Enable authentication | `false` |
-| `tap.auth.type` | Auth type (`saml` or `dex`) | `saml` |
+| `tap.auth.type` | Auth backend: `saml`, `oidc` (generic OIDC — Dex, Okta, Auth0, Keycloak, Azure AD, Google), `dex` (permanent alias of `oidc`), `descope`, `default` (also Descope) | `saml` |
 | `tap.auth.approvedEmails` | Approved email addresses | `[]` |
 | `tap.auth.approvedDomains` | Approved email domains | `[]` |
+
+### Roles & Authorization
+
+The `roles` map is shared by both SAML and OIDC backends — admins maintain a single role definition and switch backends without rewriting it.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `tap.auth.roles` | Role-name → permission map. See [SAML](/en/saml) or [OIDC](/en/oidc) for the per-role schema. | `{}` |
+| `tap.auth.rolesClaim` | JWT claim name (OIDC) or SAML attribute name carrying the user's role memberships | `role` (SAML) / `groups` (OIDC) |
+| `tap.auth.defaultRole` | Name of a role inside `tap.auth.roles` applied when an authenticated user has no matching role in their token/assertion. Empty string means no fallback (authenticated but no elevated permissions). | `""` |
+| `tap.auth.defaultFilter` | KFL filter substituted in for any role whose `filter` is empty. Set to `1==0` to opt the deployment into data-level deny-default. Empty string preserves legacy allow-all-on-blank. | `""` |
+
+> **Breaking change since the unified rollout:** empty/unset `tap.auth.roles` no longer grants all permissions — it grants none. Set `tap.auth.defaultRole` to keep a "every authenticated user gets X" baseline. Legacy `tap.auth.saml.roles` and `tap.auth.saml.roleAttribute` are no longer read; migrate to the top-level keys above.
 
 ### SAML
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `tap.auth.saml.idpMetadataUrl` | IDP metadata URL | `""` |
+| `tap.auth.saml.idpMetadataUrl` | IdP metadata URL | `""` |
 | `tap.auth.saml.x509crt` | X.509 certificate | `""` |
 | `tap.auth.saml.x509key` | X.509 private key | `""` |
-| `tap.auth.saml.roleAttribute` | Role attribute name | `role` |
-| `tap.auth.saml.roles` | Role definitions | Admin with full access |
 
-### OIDC (Dex)
+### OIDC
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `tap.auth.dexOidc.issuer` | Dex issuer URL | `""` |
-| `tap.auth.dexOidc.clientId` | Client ID | `""` |
-| `tap.auth.dexOidc.clientSecret` | Client secret | `""` |
-| `tap.auth.dexOidc.refreshTokenLifetime` | Refresh token lifetime | `3960h` |
-| `tap.auth.dexOidc.oauth2StateParamExpiry` | OAuth2 state expiry | `10m` |
-| `tap.auth.dexOidc.bypassSslCaCheck` | Bypass SSL CA check | `false` |
+| `tap.auth.oidc.issuer` | OIDC issuer URL (Dex, Okta, Auth0, Keycloak, Azure AD, Google, …) | `""` |
+| `tap.auth.oidc.clientId` | Client ID | `""` |
+| `tap.auth.oidc.clientSecret` | Client secret | `""` |
+| `tap.auth.oidc.refreshTokenLifetime` | Refresh token lifetime | `3960h` |
+| `tap.auth.oidc.oauth2StateParamExpiry` | OAuth2 `state` param expiry | `10m` |
+| `tap.auth.oidc.bypassSslCaCheck` | Bypass SSL CA check on the issuer | `false` |
+
+> **Breaking change:** `tap.auth.type=oidc` now routes to the generic OIDC middleware. Earlier releases routed `oidc` to Descope. If you were using `oidc` to mean Descope, switch to `tap.auth.type=descope` (or `default`). The `dex` label remains a permanent alias of `oidc`.
 
 ---
 

--- a/src/pages/en/oidc.md
+++ b/src/pages/en/oidc.md
@@ -1,15 +1,22 @@
 ---
-title: OIDC with DEX
-description: Configure OpenID Connect authentication using Dex as the identity provider.
+title: OIDC
+description: Configure OpenID Connect authentication and role-based access control. Works with any spec-compliant OIDC issuer — Dex, Okta, Auth0, Keycloak, Azure AD, Google.
 layout: ../../layouts/MainLayout.astro
 mascot: Cute
 ---
 
-Choose this option if **you already have a running instance** of [**Dex – A Federated OpenID Connect Provider**](https://dexidp.io/) (IdP) in your cluster **and** want to enable OIDC authentication using the Dex IdP.
+OIDC integration provides:
+1. Authentication using corporate identities through any spec-compliant OIDC issuer.
+2. Role-based feature accessibility (`authorizedActions`).
+3. Role-based traffic visibility (KFL filter applied to every query).
+
+The `roles` map and `rolesClaim` are **shared with SAML** — see the [SAML page](/en/saml) for the same configuration applied against a SAML IdP.
+
+> **Breaking change:** `tap.auth.type=oidc` now routes to the generic OIDC middleware. Earlier releases routed `oidc` to Descope. If you were using `oidc` to mean Descope, switch to `tap.auth.type=descope` (or `default`). The `dex` label remains a permanent alias of `oidc`.
 
 ## Prerequisites
 
-Add the following static client configuration to your Dex IdP's `config.yaml`:
+If you're integrating with [Dex](https://dexidp.io/), add the following static client configuration to your Dex IdP's `config.yaml`:
 
 ```yaml
 staticClients:
@@ -20,21 +27,48 @@ staticClients:
       - https://<your-kubeshark-host>/api/oauth2/callback
 ```
 
-Replace `<your-kubeshark-host>` with **Kubeshark’s** URL.
+Replace `<your-kubeshark-host>` with Kubeshark's URL.
+
+For other issuers (Okta, Auth0, Keycloak, Azure AD, Google), register an OIDC application with the same redirect URI. Make sure the application requests the `groups` scope (or whichever claim you set in `rolesClaim` below).
 
 ### Kubeshark Configuration
-
-Add the following Helm values to enable OIDC authentication using your Dex IdP:
 
 ```yaml
 # values.yaml
 
-tap: 
+tap:
   auth:
     enabled: true
-    type: dex
-    dexOidc:
-      issuer: <insert Dex IdP issuer URL here>
+    type: oidc                # canonical; `dex` is accepted as a permanent alias
+    # JWT claim carrying the user's role memberships. `groups` is the
+    # de-facto OIDC convention; some providers (e.g. Azure AD) emit a
+    # single string when the user has one role — both shapes are accepted.
+    rolesClaim: groups
+    # Optional: name of a role inside `roles` applied when an authenticated
+    # user has no matching role in their token. Empty = no fallback.
+    defaultRole: ""
+    # Optional: KFL filter substituted in for any role whose `filter` is
+    # empty. Set to "1==0" to opt the deployment into data-level deny-default.
+    # Empty string preserves the legacy allow-all-on-blank behaviour.
+    defaultFilter: ""
+    roles:
+      admin:
+        filter: ""
+        canDownloadPCAP: true
+        canUseScripting: true
+        scriptingPermissions:
+          canSave: true
+          canActivate: true
+          canDelete: true
+        canUpdateTargetedPods: true
+        canStopTrafficCapturing: true
+        canControlDissection: true
+        showAdminConsoleLink: true
+      payments-viewer:
+        filter: src.pod.namespace=="payments" or dst.pod.namespace=="payments"
+        canUseScripting: true
+    oidc:
+      issuer: <insert OIDC issuer URL here>
       clientId: kubeshark
       clientSecret: <your client password>
       refreshTokenLifetime: "3960h" # 165 days
@@ -42,40 +76,79 @@ tap:
       bypassSslCaCheck: false
 ```
 
+> **Breaking changes since the unified-roles rollout:** legacy `auth.saml.roles` and `auth.saml.roleAttribute` are no longer read — move their values to the top-level `auth.roles` and `auth.rolesClaim`. Empty/unset `auth.roles` no longer grants all permissions; admins relying on that behaviour must either populate `auth.roles` explicitly or set `auth.defaultRole`.
+
 ---
 
 **Note:**<br/>
-Set `tap.auth.dexOidc.bypassSslCaCheck: true` 
-to allow [Kubeshark](https://kubeshark.com) communication with Dex IdP having an unknown SSL Certificate Authority.
+Set `tap.auth.oidc.bypassSslCaCheck: true`
+to allow Kubeshark to communicate with an issuer presenting an unknown SSL Certificate Authority.
 
-This setting allows you to prevent such SSL CA-related errors:<br/>
+This setting allows you to prevent SSL CA-related errors:<br/>
 `tls: failed to verify certificate: x509: certificate signed by unknown authority`
 
 ---
 
-After configuring the values file, install [Kubeshark](https://kubeshark.com) with the following command:
+After configuring the values file, install Kubeshark:
 
 ```bash
 helm install kubeshark kubeshark/kubeshark -f ./values.yaml
 ```
 
-[Kubeshark](https://kubeshark.com) will now be installed with Dex-based OIDC authentication enabled.
-
 ### Try Your OIDC-Enabled Kubeshark
 
-Once OIDC is enabled, you'll be redirected to the Dex IdP login page.
+Once OIDC is enabled you'll be redirected to your IdP's login page. The screenshots below show Dex; Okta / Auth0 / Keycloak follow the same flow.
 
 **Example: Dex IdP Login Page**
 
 ![Dex IdP - Login Page](/oidc-dex-login-page.png)
 
-1. Choose a login option and click it. Your upstream IdP (Google, Microsoft, etc.) will guide you through the authentication process.
-2. After successful authentication, you’ll be directed to a page where you can grant [Kubeshark](https://kubeshark.com) access to your user information:
+1. Choose a login option. Your upstream IdP (Google, Microsoft, etc.) will guide you through authentication.
+2. Grant Kubeshark access to your user information when prompted:
 
    ![Dex IdP - Grant Access](/oidc-dex-grant-access.png)
 
-3. You’re logged in! Your email should appear in the top-right corner of the [Kubeshark](https://kubeshark.com) dashboard:
+3. You're logged in. Your email appears in the top-right of the dashboard:
 
    ![Dex IdP - Successful Login](/oidc-dex-successful-login.png)
 
-4. You’re authorized! You can now use [Kubeshark](https://kubeshark.com) as usual.
+4. You're authorized. Use Kubeshark as usual.
+
+### IdP Role Configuration
+
+Kubeshark reads role memberships from the JWT claim named in `auth.rolesClaim` (default `groups`). Configure your IdP to emit the user's group / role memberships in that claim:
+
+- **Dex** — propagates upstream group membership through the configured connector. Some connectors (LDAP, GitHub) require explicit `groups` configuration; check Dex docs for your connector.
+- **Okta** — add a groups claim to the OIDC app, scope the filter (e.g. `Starts with: hub-`) to keep unrelated groups out of the token.
+- **Auth0** — add a Rule or Action that sets `idToken['groups'] = user.groups`.
+- **Keycloak** — enable the "Groups" mapper on the client.
+- **Azure AD** — emits group object IDs by default; configure the app registration to emit group display names if you want human-readable role keys.
+
+### Filter Authorization Rules
+
+Each role can specify a KFL `filter` that limits the traffic visible to users in that role:
+
+```yaml
+filter: src.pod.namespace=="payments" or dst.pod.namespace=="payments"
+```
+
+Users with multiple roles see the union of every role's filter (logical OR). A role with `filter: ""` adds no restriction by default; if `auth.defaultFilter` is set, blank filters are substituted with that expression — the canonical opt-in to deny-default scoping.
+
+### Feature Authorization Rules
+
+Each role's flags map to UI / API actions:
+
+| Flag                                                | Gates                                                              |
+|-----------------------------------------------------|--------------------------------------------------------------------|
+| `canDownloadPCAP`                                   | PCAP download endpoints (`/pcaps/download/...`).                   |
+| `canUseScripting`                                   | Reading scripts (`GET /scripts`).                                  |
+| `scriptingPermissions.canSave`                      | `POST` / `PUT /scripts`.                                           |
+| `scriptingPermissions.canActivate`                  | Activate/deactivate scripts (`/scripts/:index/activate`).          |
+| `scriptingPermissions.canDelete`                    | Delete scripts (`DELETE /scripts/...`).                            |
+| `canUpdateTargetedPods`                             | Pod targeting endpoints (`/pods/target/...`).                      |
+| `canStopTrafficCapturing` / `canControlDissection`  | Dissection controls (`POST /settings/dissection`).                 |
+| `showAdminConsoleLink`                              | Frontend gate for the admin console link.                          |
+
+### Verifying the active role with `/whoami`
+
+`GET /whoami` returns the authenticated user's identity, resolved `authorizedActions`, and merged `authzFilters`. Useful for diagnosing "why don't I have access to X?" — the response shows exactly which roles the token claim returned (`user.roles`), which keys actually matched `auth.roles` (`user.effectiveRoles`), and the resulting permissions.

--- a/src/pages/en/oidc.md
+++ b/src/pages/en/oidc.md
@@ -16,6 +16,8 @@ The `roles` map and `rolesClaim` are **shared with SAML** — see the [SAML page
 
 ## Prerequisites
 
+> **Bundled Dex vs external IdP.** Kubeshark's Helm chart can deploy a Dex instance inside the cluster — set `tap.auth.dexConfig` in your chart values and the chart provisions Dex alongside the hub (see the [helm chart README](https://github.com/kubeshark/kubeshark/blob/master/helm-chart/README.md) for the full `dexConfig` schema). This is a convenience for clusters that don't already have an IdP; the hub still speaks generic OIDC against it. If you already run Okta, Auth0, Keycloak, Azure AD, Google, or an external Dex, leave `dexConfig` unset and just point `tap.auth.oidc.issuer` at your existing issuer.
+
 If you're integrating with [Dex](https://dexidp.io/), add the following static client configuration to your Dex IdP's `config.yaml`:
 
 ```yaml
@@ -129,7 +131,7 @@ Kubeshark reads role memberships from the JWT claim named in `auth.rolesClaim` (
 
 ### Namespace Authorization Rules
 
-Each role specifies a `namespaces` list that limits the Kubernetes namespaces whose traffic is visible to users in that role. The hub expands the list internally into a KFL filter (`src.pod.namespace.name=="…" || dst.pod.namespace.name=="…"`) AND-ed onto every query and stream.
+Each role specifies a `namespaces` list that limits the Kubernetes namespaces whose traffic is visible to users in that role. The hub expands the list internally into a KFL filter (`src.pod.namespace.name=="…" || dst.pod.namespace.name=="…"`) AND-ed onto every query and stream. Enforcement covers all hub data paths: REST queries, the legacy `/ws` stream, and the Connect-RPC streaming endpoints used by the dashboard. Earlier OIDC builds enforced action-level RBAC but skipped the Connect-RPC data path — that gap is closed, so cross-namespace entries that previously slipped through the dashboard stream are now filtered out.
 
 | Value | Effect |
 |---|---|
@@ -160,3 +162,5 @@ Each role's flags map to UI / API actions:
 ### Verifying the active role with `/whoami`
 
 `GET /whoami` returns the authenticated user's identity, resolved `authorizedActions`, and merged `authzFilters`. Useful for diagnosing "why don't I have access to X?" — the response shows exactly which roles the token claim returned (`user.roles`), which keys actually matched `auth.roles` (`user.effectiveRoles`), and the resulting permissions.
+
+The same data is surfaced in the dashboard as the **Identity & Access** modal — click your name in the top-right to open it. The modal shows the authenticated identity, claimed vs. effective roles, the per-action flag table, and the per-role namespace scope side-by-side, so non-admins can self-diagnose access without curl-ing `/whoami` directly.

--- a/src/pages/en/oidc.md
+++ b/src/pages/en/oidc.md
@@ -47,13 +47,12 @@ tap:
     # Optional: name of a role inside `roles` applied when an authenticated
     # user has no matching role in their token. Empty = no fallback.
     defaultRole: ""
-    # Optional: KFL filter substituted in for any role whose `filter` is
-    # empty. Set to "1==0" to opt the deployment into data-level deny-default.
-    # Empty string preserves the legacy allow-all-on-blank behaviour.
-    defaultFilter: ""
     roles:
       admin:
-        filter: ""
+        # Comma-separated namespace list: "" = deny all, "*" = every namespace,
+        # "foo" = literal, "foo,bar" = OR over literals, "foo-*" = glob expansion
+        # against the cluster's known namespaces.
+        namespaces: "*"
         canDownloadPCAP: true
         canUseScripting: true
         scriptingPermissions:
@@ -65,7 +64,7 @@ tap:
         canControlDissection: true
         showAdminConsoleLink: true
       payments-viewer:
-        filter: src.pod.namespace=="payments" or dst.pod.namespace=="payments"
+        namespaces: "payments"
         canUseScripting: true
     oidc:
       issuer: <insert OIDC issuer URL here>
@@ -76,7 +75,11 @@ tap:
       bypassSslCaCheck: false
 ```
 
-> **Breaking changes since the unified-roles rollout:** legacy `auth.saml.roles` and `auth.saml.roleAttribute` are no longer read — move their values to the top-level `auth.roles` and `auth.rolesClaim`. Empty/unset `auth.roles` no longer grants all permissions; admins relying on that behaviour must either populate `auth.roles` explicitly or set `auth.defaultRole`.
+> **Breaking changes since the unified-roles rollout:**
+> - Legacy `auth.saml.roles` and `auth.saml.roleAttribute` are no longer read — move their values to the top-level `auth.roles` and `auth.rolesClaim`.
+> - Empty/unset `auth.roles` no longer grants all permissions; admins relying on that behaviour must either populate `auth.roles` explicitly or set `auth.defaultRole`.
+> - Per-role `filter` (raw KFL string) was replaced with `namespaces` (comma list, see below). Configs carrying `filter:` are ignored at unmarshal — migrate to `namespaces:`.
+> - `auth.defaultFilter` is removed. The deny-default semantic moves into per-role `namespaces: ""`; opt out for admin roles with `namespaces: "*"`.
 
 ---
 
@@ -124,15 +127,20 @@ Kubeshark reads role memberships from the JWT claim named in `auth.rolesClaim` (
 - **Keycloak** — enable the "Groups" mapper on the client.
 - **Azure AD** — emits group object IDs by default; configure the app registration to emit group display names if you want human-readable role keys.
 
-### Filter Authorization Rules
+### Namespace Authorization Rules
 
-Each role can specify a KFL `filter` that limits the traffic visible to users in that role:
+Each role specifies a `namespaces` list that limits the Kubernetes namespaces whose traffic is visible to users in that role. The hub expands the list internally into a KFL filter (`src.pod.namespace.name=="…" || dst.pod.namespace.name=="…"`) AND-ed onto every query and stream.
 
-```yaml
-filter: src.pod.namespace=="payments" or dst.pod.namespace=="payments"
-```
+| Value | Effect |
+|---|---|
+| `""` (unset) | Deny all — explicit deny-default for the role. |
+| `"*"` | Every namespace; no scope filter applied. |
+| `"foo"` | Only the literal namespace `foo` (src or dst). |
+| `"foo,bar"` | OR over literal namespaces; whitespace tolerated. |
+| `"foo-*"` | Glob expansion against the cluster's currently-watched namespaces (e.g. `payments-api`, `payments-db`). Re-evaluated at each role-resolve, so newly-deployed namespaces matching the pattern become visible at the next sign-in / token refresh. |
+| `"a, b, c-*"` | Mix of literals and globs in the same list. |
 
-Users with multiple roles see the union of every role's filter (logical OR). A role with `filter: ""` adds no restriction by default; if `auth.defaultFilter` is set, blank filters are substituted with that expression — the canonical opt-in to deny-default scoping.
+Users with multiple roles see the union of every role's namespaces (logical OR). A role with `namespaces: "*"` lifts every restriction the user would otherwise carry from another role.
 
 ### Feature Authorization Rules
 

--- a/src/pages/en/saml.md
+++ b/src/pages/en/saml.md
@@ -5,130 +5,160 @@ layout: ../../layouts/MainLayout.astro
 mascot: Cute
 ---
 
-SAML integration provides the following benefits:
-1. Authentication using corporate identities
-2. Role-based traffic visibility authorization
-3. Role-based feature accessibility
+SAML integration provides:
+1. Authentication using corporate identities.
+2. Role-based feature accessibility (`authorizedActions`).
+3. Role-based traffic visibility (KFL filter applied to every query).
+
+The `roles` map and `rolesClaim` are **shared with OIDC** — see the [OIDC page](/en/oidc) for the same configuration applied against an OIDC identity provider.
 
 ### SAML Configuration Clause
 
 ```yaml
 auth:
-    enabled: false
-    type: saml
-    saml:
-      idpMetadataUrl: ""
-      x509crt: ""
-      x509key: ""
-      roleAttribute: role   # See: IDP Authorization Configuration
-      roles:
-        admin:
-          filter: ""
-          canReplayTraffic: true
-          canDownloadPCAP: true
-          canUseScripting: true
-          canUpdateTargetedPods: true
+  enabled: true
+  type: saml
+  # SAML attribute carrying the user's role memberships.
+  # In the example IdP below this is named "users-roles"; it can be any
+  # attribute name the IdP exposes.
+  rolesClaim: role
+  # Optional: name of a role inside `roles` applied when an authenticated
+  # user has no matching role in their assertion. Empty = no fallback.
+  defaultRole: ""
+  # Optional: KFL filter substituted in for any role whose `filter` is
+  # empty. Set to "1==0" to opt the deployment into data-level deny-default.
+  # Empty string preserves the legacy allow-all-on-blank behaviour.
+  defaultFilter: ""
+  roles:
+    admin:
+      filter: ""
+      canDownloadPCAP: true
+      canUseScripting: true
+      scriptingPermissions:
+        canSave: true
+        canActivate: true
+        canDelete: true
+      canUpdateTargetedPods: true
+      canStopTrafficCapturing: true
+      canControlDissection: true
+      showAdminConsoleLink: true
+  saml:
+    idpMetadataUrl: ""
+    x509crt: ""
+    x509key: ""
 ```
 
-### X.509 Certificate & Key
-**How to:**
+> **Breaking changes since the unified-roles rollout:** legacy `auth.saml.roles` and `auth.saml.roleAttribute` are no longer read — move their values to the top-level `auth.roles` and `auth.rolesClaim`. Empty/unset `auth.roles` no longer grants all permissions; admins relying on that behaviour must either populate `auth.roles` explicitly or set `auth.defaultRole`.
 
-```yaml
+### X.509 Certificate & Key
+
+```shell
 openssl genrsa -out mykey.key 2048
 openssl req -new -key mykey.key -out mycsr.csr
 openssl x509 -signkey mykey.key -in mycsr.csr -req -days 365 -out mycert.crt
 ```
 
-**What You Get:**
-- `mycert.crt` - Use this for `AUTH_SAML_X509_CRT`
-- `mykey.key` - Use this for `AUTH_SAML_X509_KEY`
+- `mycert.crt` — use for `tap.auth.saml.x509crt`.
+- `mykey.key` — use for `tap.auth.saml.x509key`.
 
+### IdP Authorization Configuration
 
-### IDP Authorization Configuration
+`auth.rolesClaim` should match the name of the SAML attribute set in the App Metadata (`app_metadata`) section of the IdP — e.g. `role`, `roles`, or any attribute name the IdP emits. The value can be a single text value or an array of values (multi-role users).
 
-The `roleAttribute` should match the name of the `key` set in the App Metadata (app_metadata) section of the IDP. It can be `role`, `roles`, or any other word. The content can be a single text value or an array of text values (to indicate multiple roles apply to the user).
+For example, in [Auth0](https://auth0.com/) it looks like this:
 
-For example, in [Auth0](https://auth0.com/), it looks like this:
+![IdP App Metadata](/app_metadata.png)
 
-![IDP App Metadata](/app_metadata.png)
-
-Each `role` is assigned a set of rules that govern the users feature accessibility and traffic visibility.
+Each role key inside `auth.roles` is matched against the values returned in this attribute.
 
 ### Filter Authorization Rules
 
-Each `role` is assigned a KFL-based (filter) authorization rule. This rule allows any traffic seen by a specific user to be filtered and limited.
-
-For example, a filter like this:
+Each role can specify a KFL `filter` that limits the traffic visible to users in that role. For example:
 
 ```yaml
-src.namespace=="ks-load" or dst.namespace=="ks-load"
+filter: src.namespace=="ks-load" or dst.namespace=="ks-load"
 ```
-This filter will limit the viewer to seeing incoming and outgoing traffic to a specific namespace named: `ks-load`.
 
-Users can be assigned multiple `roles` and be authorized to view the sum of what is authorized by all rules.
-
+Users assigned to multiple roles see the union of every role's filter (logical OR). A role with `filter: ""` adds no restriction by default; if `auth.defaultFilter` is set, blank filters are substituted with that expression — the canonical opt-in to deny-default scoping.
 
 ### Feature Authorization Rules
 
-These rules also dictate what features users can use. For example, replaying traffic, downloading PCAPs, changing pod targeting rules, using scripts.
+Each role's flags map to UI / API actions:
+
+| Flag                                          | Gates                                                                   |
+|-----------------------------------------------|-------------------------------------------------------------------------|
+| `canDownloadPCAP`                             | PCAP download endpoints (`/pcaps/download/...`).                        |
+| `canUseScripting`                             | Reading scripts (`GET /scripts`).                                       |
+| `scriptingPermissions.canSave`                | `POST` / `PUT /scripts`.                                                |
+| `scriptingPermissions.canActivate`            | Activate/deactivate scripts (`/scripts/:index/activate`).               |
+| `scriptingPermissions.canDelete`              | Delete scripts (`DELETE /scripts/...`).                                 |
+| `canUpdateTargetedPods`                       | Pod targeting endpoints (`/pods/target/...`).                           |
+| `canStopTrafficCapturing` / `canControlDissection` | Dissection controls (`POST /settings/dissection`).                  |
+| `showAdminConsoleLink`                        | Frontend gate for the admin console link.                               |
 
 ### Example
 
-Assume this configuration clause:
-
-
 ```yaml
- auth:
-    enabled: true
-    type: saml
-    saml:
-      idpMetadataUrl: https://dev-....us.auth0.com/samlp/metadata/9K...pO
-      x509crt: |
-        -----BEGIN CERTIFICATE-----
-        MIIDgzCCAmsCFDtG4VpACGCxV9cAsa6Z+9dA3suWMA0GCSqGSIb3DQEBCwUAMH4x
-        CzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRIwEAYDVQQHDAlQYWxv
-        ...
-        0tPlMoliIEacOfzyfNW/PZ/rQ36nXC5awg/ByrfkzazikZr0lv2Wnqb2K5Lns2nv
-        uR7kK02ruXgW5qfuGPBHZy5Lu+vVM++XV7kOLjWf4Bfp/Y01wYfq
-        -----END CERTIFICATE-----
-      x509key: |
-        -----BEGIN PRIVATE KEY-----
-        MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCW6rSxwgOW5ZvY
-        ...
-        jUxLqUsvrErsjl+VpUfHCloPeYpn7zC+0V/Kyk20IjckPArAfeUaqWnjLtfj7QfR
-        b6N0fptN0RJjxQIv67RVPxI=
-        -----END PRIVATE KEY-----  
-      roleAttribute: users-roles    
-      roles:
-        developers:
-          filter: src.namespace=="ks-load" or dst.namespace=="ks-load"
-          canReplayTraffic: false
-          canDownloadPCAP: false
-          canUseScripting: false
-          canUpdateTargetedPods: false
-        devops:
-          filter: src.namespace=="default" or dst.namespace=="default"
-          canReplayTraffic: true
-          canDownloadPCAP: true
-          canUseScripting: true
-          canUpdateTargetedPods: false
-        admins:
-          filter: ""
-          canReplayTraffic: true
-          canDownloadPCAP: true
-          canUseScripting: true
-          canUpdateTargetedPods: true
+auth:
+  enabled: true
+  type: saml
+  rolesClaim: users-roles
+  defaultRole: ""
+  roles:
+    developers:
+      filter: src.namespace=="ks-load" or dst.namespace=="ks-load"
+      canDownloadPCAP: false
+      canUseScripting: false
+      scriptingPermissions:
+        canSave: false
+        canActivate: false
+        canDelete: false
+      canUpdateTargetedPods: false
+    devops:
+      filter: src.namespace=="default" or dst.namespace=="default"
+      canDownloadPCAP: true
+      canUseScripting: true
+      scriptingPermissions:
+        canSave: true
+        canActivate: true
+        canDelete: true
+      canUpdateTargetedPods: false
+    admins:
+      filter: ""
+      canDownloadPCAP: true
+      canUseScripting: true
+      scriptingPermissions:
+        canSave: true
+        canActivate: true
+        canDelete: true
+      canUpdateTargetedPods: true
+      canStopTrafficCapturing: true
+      canControlDissection: true
+      showAdminConsoleLink: true
+  saml:
+    idpMetadataUrl: https://dev-....us.auth0.com/samlp/metadata/9K...pO
+    x509crt: |
+      -----BEGIN CERTIFICATE-----
+      MIIDgzCCAmsCFDtG4VpACGCxV9cAsa6Z+9dA3suWMA0GCSqGSIb3DQEBCwUAMH4x
+      ...
+      -----END CERTIFICATE-----
+    x509key: |
+      -----BEGIN PRIVATE KEY-----
+      MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCW6rSxwgOW5ZvY
+      ...
+      -----END PRIVATE KEY-----
 ```
 
-Assume a user has the following `app_metadata` in the IDP:
+A user with the `app_metadata` below:
 
 ```yaml
 {
-    users-roles: [ 
-        "devops", 
-        "developer" 
-    ] 
-} 
+  users-roles: [ "devops", "developers" ]
+}
 ```
 
-The user will see all traffic in both the `ks-load` and `default` namespaces. In terms of features, they can do anything except change Pod Targeting rules. Only users with the `admins` permission can use the Pod Targeting dialog box.
+…sees traffic in both the `ks-load` and `default` namespaces and gets the `devops` action set (everything except `canUpdateTargetedPods`/dissection control). Only users with the `admins` role can change pod targeting or dissection settings.
+
+### Verifying the active role with `/whoami`
+
+`GET /whoami` returns the authenticated user's identity, resolved `authorizedActions`, and merged `authzFilters`. Useful for diagnosing "why don't I have access to X?" — the response shows exactly which roles the IdP returned (`user.roles`), which keys actually matched `auth.roles` (`user.effectiveRoles`), and the resulting permissions.

--- a/src/pages/en/saml.md
+++ b/src/pages/en/saml.md
@@ -25,13 +25,15 @@ auth:
   # Optional: name of a role inside `roles` applied when an authenticated
   # user has no matching role in their assertion. Empty = no fallback.
   defaultRole: ""
-  # Optional: KFL filter substituted in for any role whose `filter` is
-  # empty. Set to "1==0" to opt the deployment into data-level deny-default.
-  # Empty string preserves the legacy allow-all-on-blank behaviour.
-  defaultFilter: ""
   roles:
     admin:
-      filter: ""
+      # Comma-separated namespace list controlling traffic visibility:
+      #   ""        — deny all
+      #   "*"       — every namespace
+      #   "foo"     — single literal namespace
+      #   "foo,bar" — OR over literals
+      #   "foo-*"   — glob expansion against the cluster's known namespaces
+      namespaces: "*"
       canDownloadPCAP: true
       canUseScripting: true
       scriptingPermissions:
@@ -48,7 +50,11 @@ auth:
     x509key: ""
 ```
 
-> **Breaking changes since the unified-roles rollout:** legacy `auth.saml.roles` and `auth.saml.roleAttribute` are no longer read — move their values to the top-level `auth.roles` and `auth.rolesClaim`. Empty/unset `auth.roles` no longer grants all permissions; admins relying on that behaviour must either populate `auth.roles` explicitly or set `auth.defaultRole`.
+> **Breaking changes since the unified-roles rollout:**
+> - Legacy `auth.saml.roles` and `auth.saml.roleAttribute` are no longer read — move their values to the top-level `auth.roles` and `auth.rolesClaim`.
+> - Empty/unset `auth.roles` no longer grants all permissions; admins relying on that behaviour must either populate `auth.roles` explicitly or set `auth.defaultRole`.
+> - Per-role `filter` (raw KFL string) was replaced with `namespaces` (comma list, see below). Configs carrying `filter:` are ignored at unmarshal — migrate to `namespaces:`.
+> - `auth.defaultFilter` is removed. The deny-default semantic moves into per-role `namespaces: ""`; opt out for admin roles with `namespaces: "*"`.
 
 ### X.509 Certificate & Key
 
@@ -71,15 +77,20 @@ For example, in [Auth0](https://auth0.com/) it looks like this:
 
 Each role key inside `auth.roles` is matched against the values returned in this attribute.
 
-### Filter Authorization Rules
+### Namespace Authorization Rules
 
-Each role can specify a KFL `filter` that limits the traffic visible to users in that role. For example:
+Each role specifies a `namespaces` list that limits the Kubernetes namespaces whose traffic is visible to users in that role. The hub expands the list internally into a KFL filter (`src.pod.namespace.name=="…" || dst.pod.namespace.name=="…"`) AND-ed onto every query and stream.
 
-```yaml
-filter: src.namespace=="ks-load" or dst.namespace=="ks-load"
-```
+| Value | Effect |
+|---|---|
+| `""` (unset) | Deny all — explicit deny-default for the role. |
+| `"*"` | Every namespace; no scope filter applied. |
+| `"foo"` | Only the literal namespace `foo` (src or dst). |
+| `"foo,bar"` | OR over literal namespaces; whitespace tolerated. |
+| `"foo-*"` | Glob expansion against the cluster's currently-watched namespaces (e.g. `payments-api`, `payments-db`). Re-evaluated at each role-resolve, so newly-deployed namespaces matching the pattern become visible at the next sign-in / token refresh. |
+| `"a, b, c-*"` | Mix of literals and globs in the same list. |
 
-Users assigned to multiple roles see the union of every role's filter (logical OR). A role with `filter: ""` adds no restriction by default; if `auth.defaultFilter` is set, blank filters are substituted with that expression — the canonical opt-in to deny-default scoping.
+Users assigned to multiple roles see the union of every role's namespaces (logical OR). A role with `namespaces: "*"` lifts every restriction the user would otherwise carry from another role.
 
 ### Feature Authorization Rules
 
@@ -106,7 +117,7 @@ auth:
   defaultRole: ""
   roles:
     developers:
-      filter: src.namespace=="ks-load" or dst.namespace=="ks-load"
+      namespaces: "ks-load"
       canDownloadPCAP: false
       canUseScripting: false
       scriptingPermissions:
@@ -115,7 +126,7 @@ auth:
         canDelete: false
       canUpdateTargetedPods: false
     devops:
-      filter: src.namespace=="default" or dst.namespace=="default"
+      namespaces: "default"
       canDownloadPCAP: true
       canUseScripting: true
       scriptingPermissions:
@@ -124,7 +135,7 @@ auth:
         canDelete: true
       canUpdateTargetedPods: false
     admins:
-      filter: ""
+      namespaces: "*"
       canDownloadPCAP: true
       canUseScripting: true
       scriptingPermissions:

--- a/src/pages/en/saml.md
+++ b/src/pages/en/saml.md
@@ -79,7 +79,7 @@ Each role key inside `auth.roles` is matched against the values returned in this
 
 ### Namespace Authorization Rules
 
-Each role specifies a `namespaces` list that limits the Kubernetes namespaces whose traffic is visible to users in that role. The hub expands the list internally into a KFL filter (`src.pod.namespace.name=="…" || dst.pod.namespace.name=="…"`) AND-ed onto every query and stream.
+Each role specifies a `namespaces` list that limits the Kubernetes namespaces whose traffic is visible to users in that role. The hub expands the list internally into a KFL filter (`src.pod.namespace.name=="…" || dst.pod.namespace.name=="…"`) AND-ed onto every query and stream. Enforcement covers all hub data paths: REST queries, the legacy `/ws` stream, and the Connect-RPC streaming endpoints used by the dashboard.
 
 | Value | Effect |
 |---|---|
@@ -106,6 +106,15 @@ Each role's flags map to UI / API actions:
 | `canUpdateTargetedPods`                       | Pod targeting endpoints (`/pods/target/...`).                           |
 | `canStopTrafficCapturing` / `canControlDissection` | Dissection controls (`POST /settings/dissection`).                  |
 | `showAdminConsoleLink`                        | Frontend gate for the admin console link.                               |
+
+### Behaviour when the SAML session can't be resolved
+
+If the hub fails to resolve a SAML session for a request — service provider not initialized, session cookie missing or expired, claims malformed, or the session-stored `authzActions` block is missing — both action-level and data-level RBAC fail closed:
+
+- `authorizedActions` is set to a deny-all (zero-value) action set, so every gated UI action returns 403.
+- `authzFilters` is published as an explicit deny-all KFL clause (`1==0`). The data path AND-s this into every query, so REST results, the legacy WebSocket stream, and Connect-RPC dashboard streams all return empty for the failed request, not "everything in the cluster."
+
+This closes a previous gap where a partially-broken SAML session would deny actions but leave the data path wide open. If you see "no permission" alerts paired with an empty entries list, inspect `/whoami` first — `authenticated: false` (or an `authType: saml` response with no `user`) usually points at the SAML session, not the role config.
 
 ### Example
 
@@ -173,3 +182,5 @@ A user with the `app_metadata` below:
 ### Verifying the active role with `/whoami`
 
 `GET /whoami` returns the authenticated user's identity, resolved `authorizedActions`, and merged `authzFilters`. Useful for diagnosing "why don't I have access to X?" — the response shows exactly which roles the IdP returned (`user.roles`), which keys actually matched `auth.roles` (`user.effectiveRoles`), and the resulting permissions.
+
+The same data is surfaced in the dashboard as the **Identity & Access** modal — click your name in the top-right to open it. The modal shows the authenticated identity, claimed vs. effective roles, the per-action flag table, and the per-role namespace scope side-by-side, so non-admins can self-diagnose access without curl-ing `/whoami` directly.


### PR DESCRIPTION
## Summary

Aligns the public docs with the [authz-refactoring](https://github.com/kubeshark/hub/tree/authz-refactoring) milestone's chart + hub changes. The Helm chart and chart README already moved to `tap.auth.roles` / `tap.auth.rolesClaim` / `tap.auth.defaultRole` / `tap.auth.defaultFilter` and renamed `dexOidc` → `oidc`; the public docs were still showing the legacy `tap.auth.saml.roles` / `tap.auth.dexOidc.*` paths and the obsolete `canReplayTraffic` action.

### Changes

- `helm_reference.md` — auth table rewritten: type values list, shared roles section, SAML keys trimmed, OIDC keys renamed to match the chart, two breaking-change call-outs.
- `saml.md` — `roles` / `rolesClaim` / `defaultRole` / `defaultFilter` lifted out of the `saml:` block to the top-level `auth:` block. `canReplayTraffic` dropped (no longer exists). Updated to the current `AuthorizedActions` schema. Cross-link to OIDC.
- `oidc.md` — `type: dex` → `type: oidc` (with `dex` noted as alias); `dexOidc:` → `oidc:`; new role-config section; `rolesClaim` default explained as `groups`; per-IdP notes for Dex/Okta/Auth0/Keycloak/Azure AD; `/whoami` diagnosis section.
- `config.ts` — sidebar "OIDC w/ DEX" → "OIDC" (page is now issuer-neutral).

### Breaking changes documented

1. **`AUTH_TYPE=oidc` semantic flip** — was Descope, now generic OIDC. `descope` / `default` route to Descope.
2. **Empty/unset `auth.roles` no longer grants all permissions** — admins must populate `auth.roles` or set `auth.defaultRole`.
3. **Legacy `auth.saml.roles` / `auth.saml.roleAttribute` are no longer read** — migrate values to top-level `auth.roles` / `auth.rolesClaim`.

## Test plan

- [ ] Reviewer eyeballs the rewritten pages for accuracy against the chart's current `values.yaml`.
- [ ] CI Astro build succeeds.
- [ ] Spot-check that the in-page anchors and cross-links between `saml.md` and `oidc.md` resolve correctly on the staging site.