### PR TITLE
docs: add MongoDB, MySQL, and PostgreSQL protocol dissection

### DIFF
--- a/src/pages/en/introduction.md
+++ b/src/pages/en/introduction.md
@@ -47,12 +47,13 @@ Encrypted traffic is a blind spot for most observability tools. Kubeshark remove
 
 ## Protocol Support
 
-Kubeshark supports **20+ protocols** across multiple layers:
+Kubeshark supports **23+ protocols** across multiple layers:
 
 | Category | Protocols |
 |----------|-----------|
 | **HTTP/REST** | HTTP/1.0, HTTP/1.1, HTTP/2, WebSocket, GraphQL |
 | **Messaging** | Apache Kafka, AMQP (RabbitMQ), Redis |
+| **Database** | MongoDB, MySQL, PostgreSQL |
 | **RPC** | gRPC over HTTP/2 |
 | **Authentication** | LDAP, RADIUS, DIAMETER |
 | **Network** | DNS, ICMP, TCP, UDP, SCTP |

--- a/src/pages/en/protocols.md
+++ b/src/pages/en/protocols.md
@@ -29,6 +29,14 @@ Kubeshark supports a comprehensive range of network protocols across multiple la
 | [AMQP](https://www.rabbitmq.com/amqp-0-9-1-reference.html) | Advanced Message Queuing Protocol (RabbitMQ) |
 | [Redis](https://redis.io/topics/protocol) | In-memory data structure store protocol |
 
+### Database Protocols
+
+| Protocol | Description |
+|----------|-------------|
+| [MongoDB](https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/) | MongoDB Wire Protocol |
+| [MySQL](https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_PROTOCOL.html) | MySQL Client/Server Protocol |
+| [PostgreSQL](https://www.postgresql.org/docs/current/protocol.html) | PostgreSQL Frontend/Backend Protocol |
+
 ### RPC & API Protocols
 
 | Protocol | Description |

--- a/src/pages/en/traffic_investigation.md
+++ b/src/pages/en/traffic_investigation.md
@@ -4,7 +4,7 @@ description: Kubeshark as a real-time traffic investigation and debugging.
 layout: ../../layouts/MainLayout.astro
 ---
 
-**Kubeshark** offers real-time, cluster-wide, identity-aware, protocol-level visibility into API traffic, empowering its users to see in their own eyes what's happening in all (hidden) corners of their K8s clusters. Observe all traffic,  including payloads, entering, exiting, and traversing containers, pods, namespaces, nodes, and clusters, with support for REST, GraphQL, gRPC, Redis, Kafka, RabbitMQ (AMQP), DNS, TLS, mTLS, ICMP and TCP (to diagnose TCP errors).
+**Kubeshark** offers real-time, cluster-wide, identity-aware, protocol-level visibility into API traffic, empowering its users to see in their own eyes what's happening in all (hidden) corners of their K8s clusters. Observe all traffic,  including payloads, entering, exiting, and traversing containers, pods, namespaces, nodes, and clusters, with support for REST, GraphQL, gRPC, Redis, Kafka, RabbitMQ (AMQP), MongoDB, MySQL, PostgreSQL, DNS, TLS, mTLS, ICMP and TCP (to diagnose TCP errors).
 
 Whether you are resolving issues with your infrastructure, analyzing potential threats, or delving into a security incident, **Kubeshark** can be highly valuable in pinpointing the responsible factors.
 


### PR DESCRIPTION
## Summary
- Add new **Database Protocols** section to the protocols page with MongoDB, MySQL, and PostgreSQL
- Update the introduction page protocol summary table and protocol count (20+ → 23+)
- Update the traffic investigation page to include the new database protocols

## Test plan
- [ ] Verify protocols page renders the new Database Protocols table correctly
- [ ] Verify introduction page shows the updated protocol count and table row
- [ ] Verify traffic investigation page lists the new protocols