### PR TITLE
docs: weekly update for 2026-W18

### DIFF
--- a/src/pages/en/display_filters.md
+++ b/src/pages/en/display_filters.md
@@ -69,6 +69,8 @@ http                    # HTTP traffic
 dns                     # DNS traffic
 redis                   # Redis traffic
 kafka                   # Kafka traffic
+mysql                   # MySQL traffic
+postgresql              # PostgreSQL traffic
 tls                     # TLS/encrypted traffic
 ```
 

--- a/src/pages/en/mcp/l7_tools.md
+++ b/src/pages/en/mcp/l7_tools.md
@@ -363,7 +363,7 @@ See [KFL2 Documentation](/en/v2/kfl2) for full syntax.
 | `ts` | int64 | Timestamp (Unix ms) |
 | `src` | Endpoint | Source endpoint |
 | `dst` | Endpoint | Destination endpoint |
-| `proto` | string | Protocol: `http`, `grpc`, `redis`, etc. |
+| `proto` | string | Protocol: `http`, `grpc`, `redis`, `mysql`, `postgresql`, etc. |
 | `method` | string | HTTP method or RPC name |
 | `path` | string | Request path |
 | `status` | int | Response status code |

--- a/src/pages/en/protocols.md
+++ b/src/pages/en/protocols.md
@@ -21,6 +21,13 @@ Kubeshark supports a comprehensive range of network protocols across multiple la
 | [WebSocket](https://datatracker.ietf.org/doc/html/rfc6455) | RFC 6455 | Full-duplex communication over HTTP |
 | [GraphQL](https://graphql.org/learn/serving-over-http/) | HTTP/1.1 & HTTP/2 | Query language for APIs |
 
+### Database Protocols
+
+| Protocol | Description |
+|----------|-------------|
+| [MySQL](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basics.html) | MySQL wire protocol (COM_QUERY, COM_STMT_PREPARE, COM_INIT_DB) |
+| [PostgreSQL](https://www.postgresql.org/docs/current/protocol.html) | PostgreSQL wire protocol (Simple Query and Extended Query) |
+
 ### Messaging & Streaming
 
 | Protocol | Description |

--- a/src/pages/en/v2/kfl2.md
+++ b/src/pages/en/v2/kfl2.md
@@ -165,8 +165,10 @@ Boolean variables that indicate which protocol was detected. Use these as the fi
 | `sctp` | SCTP | `gql` | GraphQL (v1 + v2) |
 | `icmp` | ICMP | `gqlv1` / `gqlv2` | GraphQL version-specific |
 | `grpc` | gRPC over HTTP/2 | `conn` / `flow` | L4 connection/flow tracking |
-| `radius` | RADIUS | `tcp_conn` / `udp_conn` | Transport-specific connections |
-| `diameter` | Diameter | `tcp_flow` / `udp_flow` | Transport-specific flows |
+| `mysql` | MySQL | `tcp_conn` / `udp_conn` | Transport-specific connections |
+| `postgresql` | PostgreSQL | `tcp_flow` / `udp_flow` | Transport-specific flows |
+| `radius` | RADIUS | | |
+| `diameter` | Diameter | | |
 
 ### Identity and Metadata Variables
 
@@ -225,6 +227,36 @@ gRPC traffic is detected as a sub-protocol of HTTP/2. When `grpc` is true, all H
 |----------|------|-------------|
 | `grpc_method` | string | gRPC method name extracted from the `:path` trailing segment (e.g. `/helloworld.Greeter/SayHello` → `SayHello`) |
 | `grpc_status` | int | gRPC status code from the `Grpc-Status` response header/trailer (defaults to `0` / OK when absent) |
+
+### MySQL Variables
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `mysql_command` | string | MySQL command name (COM_QUERY, COM_STMT_PREPARE, COM_INIT_DB) |
+| `mysql_query` | string | SQL query text |
+| `mysql_database` | string | Database name |
+| `mysql_statement_id` | int | Prepared statement identifier |
+| `mysql_request_size` | int | Request size in bytes |
+| `mysql_response_size` | int | Response size in bytes |
+| `mysql_total_size` | int | Sum of request + response sizes |
+| `mysql_success` | bool | True if response is OK (not ERR) |
+| `mysql_error_code` | int | MySQL error code |
+| `mysql_error_message` | string | MySQL error message text |
+
+### PostgreSQL Variables
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `postgresql_command` | string | Command tag (Query, Parse, Bind, Execute) |
+| `postgresql_query` | string | SQL query text |
+| `postgresql_database` | string | Database name |
+| `postgresql_user` | string | Username |
+| `postgresql_request_size` | int | Request size in bytes |
+| `postgresql_response_size` | int | Response size in bytes |
+| `postgresql_total_size` | int | Sum of request + response sizes |
+| `postgresql_success` | bool | True if no ErrorResponse |
+| `postgresql_error_code` | string | SQLSTATE error code |
+| `postgresql_error_message` | string | Error message text |
 
 ### DNS Variables
 
@@ -546,6 +578,24 @@ dst.dns != "" && !dst.dns.endsWith(".internal")
 ### Database and Messaging Filtering
 
 ```cel
+# MySQL queries
+mysql && mysql_command == "COM_QUERY"
+
+# MySQL queries to a specific database
+mysql && mysql_database == "orders"
+
+# Failed MySQL queries
+mysql && !mysql_success
+
+# PostgreSQL queries
+postgresql && postgresql_command == "Query"
+
+# PostgreSQL errors by SQLSTATE code
+postgresql && postgresql_error_code != ""
+
+# PostgreSQL queries by user
+postgresql && postgresql_user == "app_service"
+
 # Redis GET commands
 redis && redis_type == "GET"
 


### PR DESCRIPTION
Weekly documentation update covering merged PRs from 2026-04-25T17:59:32Z through now.

## Source PRs

### kubeshark/hub

- [#762 Authz refactoring descope cookies](https://github.com/kubeshark/hub/pull/762) — @corest
- [#761 Merge master into authz-refactoring](https://github.com/kubeshark/hub/pull/761) — @corest
- [#756 Authz Refactoring: Step 8: Namespaces-only role filter](https://github.com/kubeshark/hub/pull/756) — @corest
- [#755 Authz Refactoring: Step 6.1: Descope demo compatibility populator](https://github.com/kubeshark/hub/pull/755) — @corest
- [#754 Authz Refactoring: Step 6: Cross-cutting unit tests](https://github.com/kubeshark/hub/pull/754) — @corest
- [#752 Authz Refactoring: Step 5: GET /whoami identity + authz endpoint](https://github.com/kubeshark/hub/pull/752) — @corest
- [#751 Authz Refactoring: Step 4.5: Connect-RPC KFL filter injection + AUTH_DEFAULT_FILTER](https://github.com/kubeshark/hub/pull/751) — @corest
- [#750 :lock: Descope: Mirror auth headers to cookies](https://github.com/kubeshark/hub/pull/750) — @tiptophelmet
- [#749 Authz Refactoring: Step 4: Rename AUTH_TYPE labels (oidc/dex/descope)](https://github.com/kubeshark/hub/pull/749) — @corest
- [#748 Authz refactoring step 3 claim extraction](https://github.com/kubeshark/hub/pull/748) — @corest
- [#746 Update deps for PostgreSQL support](https://github.com/kubeshark/hub/pull/746) — @alongir
- [#745 Add MySQL dissector support](https://github.com/kubeshark/hub/pull/745) — @alongir
- [#736 Authz Refactoring: Step 2: Introduce unified AUTH_ROLES config](https://github.com/kubeshark/hub/pull/736) — @corest
- [#735 Authz Refactoring: Step 1: Lift authz context helpers into authutils package](https://github.com/kubeshark/hub/pull/735) — @corest

### kubeshark/worker

- [#1138 Fix http api-server one-leg](https://github.com/kubeshark/worker/pull/1138) — @iluxa
- [#1137 Remove sliding-window TLS heuristic from all L7 dissectors](https://github.com/kubeshark/worker/pull/1137) — @alongir
- [#1135 Fix commit message with parentheses pipeline check ](https://github.com/kubeshark/worker/pull/1135) — @corest
- [#1129 Add PostgreSQL wire protocol dissector](https://github.com/kubeshark/worker/pull/1129) — @alongir
- [#1126 Add MySQL wire protocol dissector](https://github.com/kubeshark/worker/pull/1126) — @alongir

### kubeshark/front

- [#1208 :lipstick: Show timestamp in entry details](https://github.com/kubeshark/front/pull/1208) — @tiptophelmet
- [#1207 :lipstick: Disable history-range button in delayed-dissection mode](https://github.com/kubeshark/front/pull/1207) — @tiptophelmet
- [#1205 :lock: Ensure auth credentials presence on all API requests ](https://github.com/kubeshark/front/pull/1205) — @tiptophelmet
- [#1203 💄 Adjust KFL boxes](https://github.com/kubeshark/front/pull/1203) — @tiptophelmet
- [#1202 Revert "Show time boundaries above snapshots table"](https://github.com/kubeshark/front/pull/1202) — @tiptophelmet
- [#1200 Add PostgreSQL protocol UI support](https://github.com/kubeshark/front/pull/1200) — @alongir
- [#1197 :sparkles: Decode multi-message gRPC request/response payloads](https://github.com/kubeshark/front/pull/1197) — @tiptophelmet
- [#1196 Add MySQL protocol UI support](https://github.com/kubeshark/front/pull/1196) — @alongir

### kubeshark/kfl2

- [#28 Add PostgreSQL protocol filter variables](https://github.com/kubeshark/kfl2/pull/28) — @alongir
- [#26 Add MySQL protocol filter variables](https://github.com/kubeshark/kfl2/pull/26) — @alongir
- [#23 Add grpc, grpc_method, grpc_status KFL variables](https://github.com/kubeshark/kfl2/pull/23) — @iluxa

### kubeshark/api2

- [#86 Add PostgreSQL wire protocol protobuf definitions](https://github.com/kubeshark/api2/pull/86) — @alongir
- [#85 Add MySQL wire protocol protobuf definitions](https://github.com/kubeshark/api2/pull/85) — @alongir
- [#83 Stream history implementation](https://github.com/kubeshark/api2/pull/83) — @iluxa

