### PR TITLE
Update licensing docs for Community edition changes

### DIFF
--- a/src/pages/en/air_gapped.md
+++ b/src/pages/en/air_gapped.md
@@ -10,7 +10,7 @@ layout: ../../layouts/MainLayout.astro
 
 [Contact us](https://kubeshark.com/contact-us) to get an ENTERPRISE license.
 
-> A PRO license requires an active internet connection and cannot function properly in an air-gapped environment.
+> Community and Pro licenses require an active internet connection and cannot function properly in an air-gapped environment.
 
 ## Docker Registry
 

--- a/src/pages/en/helm_reference.md
+++ b/src/pages/en/helm_reference.md
@@ -349,7 +349,7 @@ The `roles` map is shared by both SAML and OIDC backends — admins maintain a s
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `license` | Pro/Enterprise license key | `""` |
+| `license` | License key (Community, Pro, or Enterprise) | `""` |
 | `timezone` | IANA time zone | `""` (local) |
 | `headless` | Headless mode | `false` |
 | `internetConnectivity` | Allow internet requests | `true` |

--- a/src/pages/en/license_portal.md
+++ b/src/pages/en/license_portal.md
@@ -32,9 +32,9 @@ The License tab provides instructions for obtaining and using your license key.
 
 ![License Tab](/license_portal_license.png)
 
-### Pro & Enterprise Users
+### Downloading and Applying a License Key
 
-Pro and Enterprise users can download their license key from the portal and configure it for cluster-wide access, allowing all team members to use Kubeshark without individual authentication.
+All users — Community, Pro, and Enterprise — can download their license key from the portal and configure it as a Helm value.
 
 **With Helm:**
 
@@ -57,16 +57,7 @@ license: <your-license-key>
 
 You can also store the license key as a Kubernetes secret for secure deployment.
 
-> **Note:** Pro licenses require an active internet connection — telemetry must succeed for the license to remain valid. Enterprise licenses can operate in air-gapped environments with no internet connectivity.
-
-### Community Users
-
-Community licenses are personal and require:
-
-- **Cloud login**: Users must log in to access Kubeshark
-- **Internet connectivity**: An active connection to https://api.kubeshark.com is required
-
-Community users will see instructions on how to log in to obtain their license. The license key cannot be downloaded or set as a Helm value.
+> **Note:** Community and Pro licenses require an active internet connection — telemetry must succeed for the license to remain valid. Only Enterprise licenses can operate in air-gapped environments with no internet connectivity.
 
 ## Subscription Tab
 
@@ -104,11 +95,11 @@ Licensees can remove their license key from a cluster by:
 
 > Only the Licensee can remove their license key.
 
-## Pro & Enterprise Features
+## License Key Features
 
 ### Cluster-Wide Dashboard Access
 
-When a license key is configured locally in the cluster, all users within your organization can access the Kubeshark dashboard without requiring individual authentication. This applies to both Pro and Enterprise licenses.
+When a license key is configured locally in the cluster, all users within your organization can access the Kubeshark dashboard without requiring individual authentication. This applies to all license editions (Community, Pro, and Enterprise).
 
 ### Optional IDP Authentication
 

--- a/src/pages/en/plans.md
+++ b/src/pages/en/plans.md
@@ -9,7 +9,7 @@ layout: ../../layouts/MainLayout.astro
 The Community edition is designed for small workloads:
 
 - Up to **3 nodes** or **60 pods**
-- Single-user license requiring cloud login
+- Download a license key from the [License Portal](https://console.kubeshark.com) and set it as a Helm value
 - Requires internet connectivity
 - Community support
 
@@ -59,10 +59,10 @@ The Enterprise edition includes the complete feature set:
 | Real-time protocol visibility | Yes | Yes | Yes |
 | TLS decryption | Yes | Yes | Yes |
 | Traffic recording & offline analysis | Yes | Yes | Yes |
-| License key download | No | Yes | Yes |
-| Cloud login required | Yes | No | No |
+| License key download | Yes | Yes | Yes |
+| Cloud login required | No | No | No |
 | Internet required | Yes | Yes | No (air-gapped OK) |
-| Multi-user access | No | Yes | Yes |
+| Multi-user access | Yes | Yes | Yes |
 | Air-gapped support | No | No | Yes |
 | AI root cause analysis | No | No | Yes |
 | Dedicated support | No | No | Yes |

--- a/src/pages/en/pro.md
+++ b/src/pages/en/pro.md
@@ -6,7 +6,7 @@ layout: ../../layouts/MainLayout.astro
 
 ## Community (Free)
 
-The Community edition is offered at no cost and supports clusters of up to 4 nodes and up to 80 pods. Requires cloud login.
+The Community edition is offered at no cost and supports clusters of up to 4 nodes and up to 80 pods. Download a license key from the [License Portal](https://console.kubeshark.com) and set it as a Helm value. Requires internet connectivity.
 
 > To get started with the Community edition, [install **Kubeshark**](/en/install).
 

--- a/src/pages/en/pro_upgrade.md
+++ b/src/pages/en/pro_upgrade.md
@@ -31,7 +31,7 @@ license: <your-license-key>
 
 Once the license key is set, all users in the cluster can access Kubeshark without individual authentication.
 
-> **Note:** Pro licenses require an active internet connection. Telemetry must succeed for the license to remain valid.
+> **Note:** Community and Pro licenses require an active internet connection. Telemetry must succeed for the license to remain valid.
 
 ## Downgrading
 


### PR DESCRIPTION
## Summary

- **Community is no longer a single-user license** — removed all "single user" and "cloud login required" references for Community
- **All editions support license keys** — Community, Pro, and Enterprise license keys can now be downloaded from the [License Portal](https://console.kubeshark.com) and set as a Helm value
- **Internet connectivity requirement clarified** — both Community and Pro require internet; only Enterprise supports air-gapped environments

## Files changed

- `plans.md` — updated Community description and feature comparison table
- `license_portal.md` — unified license key instructions for all editions, removed Community-specific cloud login section
- `pro.md` — updated Community description
- `pro_upgrade.md` — updated internet connectivity note to include Community
- `air_gapped.md` — updated callout to mention Community alongside Pro
- `helm_reference.md` — updated `license` parameter description to include Community

## Test plan

- [ ] Verify all links to console.kubeshark.com resolve correctly
- [ ] Review that no references to "single user" or "cloud login" remain for Community
- [ ] Confirm feature comparison table accurately reflects new licensing model