### PR TITLE
Restore TLS & Decryption sidebar section

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,10 @@ export const SIDEBAR: Sidebar = {
       // { text: 'PCAP Dumper (Capturing Raw Traffic)', link: 'en/raw_traffic_capture' },
       // { text: 'Envoy/Istio Support', link: 'en/envoy' },
     ],
+    'TLS & Decryption': [
+      { text: 'TLS Decryption', link: 'en/encrypted_traffic' },
+      { text: 'TLS Handshake Inspection', link: 'en/tls_handshake_inspection' },
+    ],
     'Dashboard': [
       { text: 'Overview', link: 'en/ui' },
       { text: 'L4/L7 Workload Map', link: 'en/v2/service_map' },


### PR DESCRIPTION
## Summary
- Restores the `TLS & Decryption` sidebar section that was accidentally removed in commit 3186d6e (Add images to the tlsx dissector)
- Re-adds links for **TLS Decryption** and **TLS Handshake Inspection** as a dedicated section between Core Concepts and Dashboard

## Test plan
- [ ] Verify the TLS & Decryption section appears in the sidebar
- [ ] Confirm both TLS Decryption and TLS Handshake Inspection links work