### PR TITLE
docs: weekly update for 2026-W21

### DIFF
--- a/src/pages/en/display_filters.md
+++ b/src/pages/en/display_filters.md
@@ -69,7 +69,8 @@ http                    # HTTP traffic
 dns                     # DNS traffic
 redis                   # Redis traffic
 kafka                   # Kafka traffic
-tls                     # TLS/encrypted traffic
+tls                     # TLS/encrypted traffic (eBPF-intercepted)
+tlsx                    # TLS handshake inspection (ClientHello/ServerHello)
 ```
 
 ### By HTTP Status

--- a/src/pages/en/v2/kfl2.md
+++ b/src/pages/en/v2/kfl2.md
@@ -117,6 +117,18 @@ timestamp > now() - duration("5m")
 
 Pod fields automatically fall back to service data when pod info is unavailable — `dst.pod.namespace` works even when only service-level resolution exists.
 
+For traffic involving non-namespaced endpoints (IPs that don't resolve to a pod or service), the namespace field contains an identity label instead:
+
+| Label | Meaning |
+|-------|---------|
+| `internal` | Cluster-internal IP — node, pod CIDR, or RFC 1918 private address |
+| `public` | Globally routable IP address |
+
+```cel
+dst.pod.namespace == "internal"    // traffic to cluster-internal non-pod IPs
+src.pod.namespace == "public"      // traffic from public IPs
+```
+
 #### Labels and Annotations
 
 | Variable | Type | Description |
@@ -128,12 +140,18 @@ Pod fields automatically fall back to service data when pod info is unavailable 
 | `local_process_name` | string | Process name on the local peer |
 | `remote_process_name` | string | Process name on the remote peer |
 
-Always use `map_get()` for labels and annotations — direct access like `local_labels["app"]` errors if the key doesn't exist:
+You can access labels and annotations directly — missing keys safely return an empty string:
+
+```cel
+local_labels["app"] == "checkout"
+remote_labels["version"] == "canary"
+"tier" in local_labels
+```
+
+`map_get()` also works and is equivalent for labels and annotations:
 
 ```cel
 map_get(local_labels, "app", "") == "checkout"
-map_get(remote_labels, "version", "") == "canary"
-"tier" in local_labels
 ```
 
 #### DNS Resolution
@@ -159,7 +177,8 @@ Boolean variables that indicate which protocol was detected. Use these as the fi
 |----------|----------|----------|----------|
 | `http` | HTTP/1.1, HTTP/2 | `redis` | Redis |
 | `dns` | DNS | `kafka` | Kafka |
-| `tls` | TLS/SSL | `amqp` | AMQP |
+| `tls` | TLS/SSL (eBPF-intercepted) | `amqp` | AMQP |
+| `tlsx` | TLS handshake (ClientHello/ServerHello) | | |
 | `tcp` | TCP | `ldap` | LDAP |
 | `udp` | UDP | `ws` | WebSocket |
 | `sctp` | SCTP | `gql` | GraphQL (v1 + v2) |
@@ -446,8 +465,8 @@ src.service.name == "api-gateway" && dst.service.name == "user-service"
 # Traffic involving production namespace
 "production" in namespaces
 
-# Filter by pod labels (safe access)
-map_get(local_labels, "app", "") == "payments"
+# Filter by pod labels
+local_labels["app"] == "payments"
 
 # Filter by process name
 local_process_name == "nginx"
@@ -666,7 +685,7 @@ When a variable is not present in an entry, KFL uses these defaults:
 1. **Protocol flags first** — `http && ...` is faster than `... && http`
 2. **`startsWith`/`endsWith` over `contains`** — prefix/suffix checks are faster
 3. **Specific ports before string ops** — `dst.port == 80` is cheaper than `url.contains(...)`
-4. **Use `map_get` for labels** — avoids errors on missing keys
+4. **Labels are safe to access directly** — `local_labels["app"]` returns `""` if the key is missing
 5. **Keep filters simple** — CEL short-circuits on `&&`, so put cheap checks first
 6. **Empty filters match all** — an empty filter string matches all traffic
 


### PR DESCRIPTION
Weekly documentation update covering merged PRs from 2026-05-16T01:06:08Z through now.

## Source PRs

### kubeshark/hub

- [#798 Update rpcstreamer to address verbose grpc disconnects logs](https://github.com/kubeshark/hub/pull/798) — @corest
- [#797 Add dependencies tracker for api2/kfl2](https://github.com/kubeshark/hub/pull/797) — @corest
- [#796 Bump api2 and kfl2 to latest](https://github.com/kubeshark/hub/pull/796) — @alongir
- [#795 Replace unresolved with meaningful identity labels for non-namespaced endpoints](https://github.com/kubeshark/hub/pull/795) — @iluxa
- [#792 Add L7 data boundaries MCP tool, API endpoint and frontend LIVE filter button](https://github.com/kubeshark/hub/pull/792) — @iluxa
- [#785 Bump api2 for TLS handshake fields](https://github.com/kubeshark/hub/pull/785) — @alongir

### kubeshark/worker

- [#1162 Add tracer submodule reference gate](https://github.com/kubeshark/worker/pull/1162) — @corest
- [#1161 Add dependencies tracker for api2/kfl2](https://github.com/kubeshark/worker/pull/1161) — @corest
- [#1160 Bump api2 and kfl2 to latest](https://github.com/kubeshark/worker/pull/1160) — @alongir
- [#1158 Add L7 data boundaries MCP tool, API endpoint and frontend LIVE filter button](https://github.com/kubeshark/worker/pull/1158) — @iluxa
- [#1153 Improve TLS dissector: SNI summary, TLS 1.3 detection, consistency](https://github.com/kubeshark/worker/pull/1153) — @alongir

### kubeshark/front

- [#1238 Disable logged as in demo mode](https://github.com/kubeshark/front/pull/1238) — @corest
- [#1237 Add dependencies tracker for api2](https://github.com/kubeshark/front/pull/1237) — @corest
- [#1235 Replace unresolved with meaningful identity labels for non-namespaced endpoints](https://github.com/kubeshark/front/pull/1235) — @iluxa
- [#1234 Responsive snapshot creation dialog](https://github.com/kubeshark/front/pull/1234) — @tiptophelmet
- [#1232 Add L7 data boundaries MCP tool, API endpoint and frontend LIVE filter button](https://github.com/kubeshark/front/pull/1232) — @iluxa
- [#1228 Update TLS proto types with ClientHello/ServerHello fields](https://github.com/kubeshark/front/pull/1228) — @alongir

### kubeshark/kfl2

- [#34 Replace unresolved with meaningful identity labels for non-namespaced endpoints](https://github.com/kubeshark/kfl2/pull/34) — @iluxa
- [#33 Fix tlsx protocol case in buildProtocolDeclarations](https://github.com/kubeshark/kfl2/pull/33) — @alongir
- [#32 Make direct label/annotation access safe on missing keys](https://github.com/kubeshark/kfl2/pull/32) — @iluxa

### kubeshark/api2

- [#94 rpcstreamer: don't log benign gRPC cancellations as error](https://github.com/kubeshark/api2/pull/94) — @corest
- [#93 Add L7 data boundaries MCP tool, API endpoint and frontend LIVE filter button](https://github.com/kubeshark/api2/pull/93) — @iluxa

