### PR TITLE
docs: rewrite auth pages for the permissions refactor

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,7 @@ export const SIDEBAR: Sidebar = {
       { text: 'Workload Resources', link: 'en/workload_resources' },
       { text: 'SAML', link: 'en/saml' },
       { text: 'OIDC w/ DEX', link: 'en/oidc' },
+      { text: 'Roles & Permissions', link: 'en/roles' },
       { text: 'Reverse Proxy w/ Custom Path', link: 'en/custom_path' },
       { text: 'EFS Persistent Volume', link: 'en/efs' },
       { text: 'Node Scheduling', link: 'en/node_scheduling' },

--- a/src/pages/en/helm_reference.md
+++ b/src/pages/en/helm_reference.md
@@ -206,19 +206,20 @@ Complete reference for Kubeshark Helm configuration values.
 
 ### Roles & Authorization
 
-The `roles` map is shared by both SAML and OIDC backends — admins maintain a single role definition and switch backends without rewriting it.
+The role configuration is shared by both SAML and OIDC backends — admins maintain a single set of definitions and switch backends without rewriting them. See [Roles & Permissions](/en/roles) for the full model (built-in roles, capability vocabulary, custom roles, namespace scope, license-side feature ceiling).
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `tap.auth.roles` | Role-name → permission map. Each role carries action flags plus `namespaces` (comma list controlling traffic visibility — `""` deny, `"*"` allow-all, `"foo"` literal, `"foo,bar"` OR, `"foo-*"` glob expansion against the cluster's watched namespaces). See [SAML](/en/saml) or [OIDC](/en/oidc) for the full per-role schema. | `{}` |
-| `tap.auth.rolesClaim` | JWT claim name (OIDC) or SAML attribute name carrying the user's role memberships | `role` (SAML) / `groups` (OIDC) |
-| `tap.auth.defaultRole` | Name of a role inside `tap.auth.roles` applied when an authenticated user has no matching role in their token/assertion. Empty string means no fallback (authenticated but no elevated permissions). | `""` |
+| `tap.auth.rolesClaim` | JWT claim name (OIDC) or SAML attribute name carrying the user's group / role memberships. | `groups` |
+| `tap.auth.defaultRole` | Built-in role (`kubeshark-admin` / `kubeshark-realtime` / `kubeshark-snapshot` / `kubeshark-viewer`) or custom role applied when an authenticated user has no recognized claim value. Empty string means strict-deny (authenticated but no capabilities). | `kubeshark-viewer` |
+| `tap.auth.groupMapping` | Map of SSO group / attribute value → role name. Values may reference one of the four built-in roles or a custom role declared under `tap.auth.roles`. Built-in role names also identity-match without an entry here. | `{}` |
+| `tap.auth.roles` | Operator-defined custom roles, keyed by role name. Each role declares `capabilities` (closed vocabulary — see [Roles & Permissions](/en/roles)) and `namespaces` (comma list with `*` and glob support: `""` deny, `"*"` allow-all, `"foo"` literal, `"foo,bar"` OR, `"foo-*"` glob). Names starting with `kubeshark-` are reserved and rejected at hub startup. | `{}` |
 
-> **Breaking changes since the unified rollout:**
-> - Empty/unset `tap.auth.roles` no longer grants all permissions — it grants none. Set `tap.auth.defaultRole` to keep a "every authenticated user gets X" baseline.
-> - Per-role `filter` (raw KFL string) was replaced with `namespaces` (comma list). Configs carrying `filter:` are silently ignored; migrate.
-> - `tap.auth.defaultFilter` is removed; `namespaces: ""` is the explicit per-role deny-default.
+> **Breaking changes since the unified-roles rollout:**
+> - Per-role action flags (`canDownloadPCAP`, `canUseScripting`, `scriptingPermissions`, etc.) are replaced by a closed `capabilities` vocabulary. See [Roles & Permissions](/en/roles).
 > - Legacy `tap.auth.saml.roles` and `tap.auth.saml.roleAttribute` are no longer read; migrate to the top-level keys above.
+> - Per-role `filter` (raw KFL string) is replaced by `namespaces` (comma list). Configs carrying `filter:` are ignored at unmarshal — migrate.
+> - `tap.auth.defaultFilter` is removed; per-role `namespaces: ""` is the explicit deny-default.
 
 ### SAML
 

--- a/src/pages/en/oidc.md
+++ b/src/pages/en/oidc.md
@@ -6,13 +6,14 @@ mascot: Cute
 ---
 
 OIDC integration provides:
-1. Authentication using corporate identities through any spec-compliant OIDC issuer.
-2. Role-based feature accessibility (`authorizedActions`).
-3. Role-based traffic visibility (KFL filter applied to every query).
 
-The `roles` map and `rolesClaim` are **shared with SAML** — see the [SAML page](/en/saml) for the same configuration applied against a SAML IdP.
+1. **Authentication** using corporate identities through any spec-compliant OIDC issuer.
+2. **Role-based authorization** — every authenticated user is resolved to one of four built-in roles (or a custom role you define), which controls which UI surfaces and API endpoints they can use.
+3. **Namespace-scoped data visibility** — custom roles can be limited to a comma-separated list of Kubernetes namespaces; the hub injects a server-side filter so users only see traffic from their scope.
 
-> **Breaking change:** `tap.auth.type=oidc` now routes to the generic OIDC middleware. Earlier releases routed `oidc` to Descope. If you were using `oidc` to mean Descope, switch to `tap.auth.type=descope` (or `default`). The `dex` label remains a permanent alias of `oidc`.
+The role configuration (`tap.auth.roles`, `tap.auth.rolesClaim`, `tap.auth.groupMapping`, `tap.auth.defaultRole`) is **shared with SAML** — see the [Roles & Permissions page](/en/roles) for the full vocabulary. The [SAML page](/en/saml) covers the same role model applied against a SAML IdP.
+
+> **Breaking change:** `tap.auth.type=oidc` routes to the generic OIDC middleware. Earlier releases routed `oidc` to Descope. If you were using `oidc` to mean Descope, switch to `tap.auth.type=descope` (or `default`). The `dex` label remains a permanent alias of `oidc`.
 
 ## Prerequisites
 
@@ -33,7 +34,7 @@ Replace `<your-kubeshark-host>` with Kubeshark's URL.
 
 For other issuers (Okta, Auth0, Keycloak, Azure AD, Google), register an OIDC application with the same redirect URI. Make sure the application requests the `groups` scope (or whichever claim you set in `rolesClaim` below).
 
-### Kubeshark Configuration
+## Kubeshark Configuration
 
 ```yaml
 # values.yaml
@@ -41,58 +42,45 @@ For other issuers (Okta, Auth0, Keycloak, Azure AD, Google), register an OIDC ap
 tap:
   auth:
     enabled: true
-    type: oidc                # canonical; `dex` is accepted as a permanent alias
-    # JWT claim carrying the user's role memberships. `groups` is the
-    # de-facto OIDC convention; some providers (e.g. Azure AD) emit a
-    # single string when the user has one role — both shapes are accepted.
+    type: oidc                       # canonical; `dex` is accepted as a permanent alias
+    # JWT claim carrying the user's group / role memberships. `groups` is
+    # the de-facto OIDC convention; some providers (e.g. Azure AD) emit a
+    # single string when the user has one group — both shapes are accepted.
     rolesClaim: groups
-    # Optional: name of a role inside `roles` applied when an authenticated
-    # user has no matching role in their token. Empty = no fallback.
-    defaultRole: ""
+    # Built-in role applied when an authenticated user has no group that
+    # maps to a role. Set to "" for strict-deny (authenticated but no
+    # capabilities). Default in the chart is `kubeshark-viewer`.
+    defaultRole: kubeshark-viewer
+    # Map SSO groups → role names. Names may reference one of the four
+    # built-in roles (kubeshark-admin / kubeshark-realtime /
+    # kubeshark-snapshot / kubeshark-viewer) or a custom role declared
+    # under `roles` below.
+    groupMapping:
+      sso-engineering-leads: kubeshark-admin
+      sso-sre-oncall: kubeshark-realtime
+      sso-support: kubeshark-viewer
+      payments-team: payments-viewer    # custom role, see `roles` below
+    # Custom (operator-defined) roles. Each role declares its capability
+    # set + namespace scope. Names starting with `kubeshark-` are
+    # reserved for built-ins and will be rejected at hub startup.
     roles:
-      admin:
-        # Comma-separated namespace list: "" = deny all, "*" = every namespace,
-        # "foo" = literal, "foo,bar" = OR over literals, "foo-*" = glob expansion
-        # against the cluster's known namespaces.
-        namespaces: "*"
-        canDownloadPCAP: true
-        canUseScripting: true
-        scriptingPermissions:
-          canSave: true
-          canActivate: true
-          canDelete: true
-        canUpdateTargetedPods: true
-        canStopTrafficCapturing: true
-        canControlDissection: true
-        showAdminConsoleLink: true
       payments-viewer:
-        namespaces: "payments"
-        canUseScripting: true
+        capabilities:
+          - snapshot:read
+        namespaces: "payments,checkout"
     oidc:
       issuer: <insert OIDC issuer URL here>
       clientId: kubeshark
       clientSecret: <your client password>
-      refreshTokenLifetime: "3960h" # 165 days
+      refreshTokenLifetime: "3960h"      # 165 days
       oauth2StateParamExpiry: "10m"
       bypassSslCaCheck: false
 ```
 
-> **Breaking changes since the unified-roles rollout:**
-> - Legacy `auth.saml.roles` and `auth.saml.roleAttribute` are no longer read — move their values to the top-level `auth.roles` and `auth.rolesClaim`.
-> - Empty/unset `auth.roles` no longer grants all permissions; admins relying on that behaviour must either populate `auth.roles` explicitly or set `auth.defaultRole`.
-> - Per-role `filter` (raw KFL string) was replaced with `namespaces` (comma list, see below). Configs carrying `filter:` are ignored at unmarshal — migrate to `namespaces:`.
-> - `auth.defaultFilter` is removed. The deny-default semantic moves into per-role `namespaces: ""`; opt out for admin roles with `namespaces: "*"`.
-
----
-
-**Note:**<br/>
-Set `tap.auth.oidc.bypassSslCaCheck: true`
-to allow Kubeshark to communicate with an issuer presenting an unknown SSL Certificate Authority.
-
-This setting allows you to prevent SSL CA-related errors:<br/>
-`tls: failed to verify certificate: x509: certificate signed by unknown authority`
-
----
+> **Notes**
+> - Set `tap.auth.oidc.bypassSslCaCheck: true` to allow the hub to communicate with an issuer presenting an unknown SSL Certificate Authority. This prevents errors like `tls: failed to verify certificate: x509: certificate signed by unknown authority`. Do not use in production unless you understand the trust implications.
+> - Unknown capability strings under a custom role are dropped with a warning at hub startup (visible in `kubectl logs`). The capability vocabulary is closed — see [Roles & Permissions](/en/roles).
+> - Custom role names MUST appear in `groupMapping` to participate in resolution. Identity-match (SSO group name === role name) only works for the four built-in `kubeshark-*` names.
 
 After configuring the values file, install Kubeshark:
 
@@ -100,7 +88,7 @@ After configuring the values file, install Kubeshark:
 helm install kubeshark kubeshark/kubeshark -f ./values.yaml
 ```
 
-### Try Your OIDC-Enabled Kubeshark
+## Try Your OIDC-Enabled Kubeshark
 
 Once OIDC is enabled you'll be redirected to your IdP's login page. The screenshots below show Dex; Okta / Auth0 / Keycloak follow the same flow.
 
@@ -119,48 +107,30 @@ Once OIDC is enabled you'll be redirected to your IdP's login page. The screensh
 
 4. You're authorized. Use Kubeshark as usual.
 
-### IdP Role Configuration
+## IdP Group / Claim Configuration
 
-Kubeshark reads role memberships from the JWT claim named in `auth.rolesClaim` (default `groups`). Configure your IdP to emit the user's group / role memberships in that claim:
+Kubeshark reads role memberships from the JWT claim named in `tap.auth.rolesClaim` (default `groups`). Configure your IdP to emit the user's group / role memberships in that claim:
 
 - **Dex** — propagates upstream group membership through the configured connector. Some connectors (LDAP, GitHub) require explicit `groups` configuration; check Dex docs for your connector.
-- **Okta** — add a groups claim to the OIDC app, scope the filter (e.g. `Starts with: hub-`) to keep unrelated groups out of the token.
+- **Okta** — add a groups claim to the OIDC app, scope the filter (e.g. `Starts with: kubeshark-` or `Starts with: sso-`) to keep unrelated groups out of the token.
 - **Auth0** — add a Rule or Action that sets `idToken['groups'] = user.groups`.
 - **Keycloak** — enable the "Groups" mapper on the client.
 - **Azure AD** — emits group object IDs by default; configure the app registration to emit group display names if you want human-readable role keys.
 
-### Namespace Authorization Rules
+## Role Resolution
 
-Each role specifies a `namespaces` list that limits the Kubernetes namespaces whose traffic is visible to users in that role. The hub expands the list internally into a KFL filter (`src.pod.namespace.name=="…" || dst.pod.namespace.name=="…"`) AND-ed onto every query and stream. Enforcement covers all hub data paths: REST queries, the legacy `/ws` stream, and the Connect-RPC streaming endpoints used by the dashboard. Earlier OIDC builds enforced action-level RBAC but skipped the Connect-RPC data path — that gap is closed, so cross-namespace entries that previously slipped through the dashboard stream are now filtered out.
+When a user signs in, the hub walks the claim values in this order:
 
-| Value | Effect |
-|---|---|
-| `""` (unset) | Deny all — explicit deny-default for the role. |
-| `"*"` | Every namespace; no scope filter applied. |
-| `"foo"` | Only the literal namespace `foo` (src or dst). |
-| `"foo,bar"` | OR over literal namespaces; whitespace tolerated. |
-| `"foo-*"` | Glob expansion against the cluster's currently-watched namespaces (e.g. `payments-api`, `payments-db`). Re-evaluated at each role-resolve, so newly-deployed namespaces matching the pattern become visible at the next sign-in / token refresh. |
-| `"a, b, c-*"` | Mix of literals and globs in the same list. |
+1. For each value, check `groupMapping`. If present, the mapped role becomes a candidate.
+2. Otherwise, if the value identity-matches a built-in role name (`kubeshark-admin`, `kubeshark-realtime`, `kubeshark-snapshot`, `kubeshark-viewer`), it becomes a candidate.
+3. Anything else is silently dropped.
+4. The highest-precedence built-in candidate wins (`admin > realtime > snapshot > viewer`). Built-in roles always rank above custom roles when both match.
+5. If no candidates remain, `defaultRole` is applied. If `defaultRole` is empty, the user is authenticated but has no capabilities (strict-deny).
 
-Users with multiple roles see the union of every role's namespaces (logical OR). A role with `namespaces: "*"` lifts every restriction the user would otherwise carry from another role.
+See [Roles & Permissions](/en/roles) for the full algorithm, capability vocabulary, and namespace-scope semantics.
 
-### Feature Authorization Rules
+## Verifying the active role with `/whoami`
 
-Each role's flags map to UI / API actions:
+`GET /whoami` returns the authenticated user's identity, resolved `role`, effective `capabilities`, and any `authzFilters` derived from the role's namespace scope. Useful for diagnosing access issues — the response shows exactly which role was resolved and which capabilities are active.
 
-| Flag                                                | Gates                                                              |
-|-----------------------------------------------------|--------------------------------------------------------------------|
-| `canDownloadPCAP`                                   | PCAP download endpoints (`/pcaps/download/...`).                   |
-| `canUseScripting`                                   | Reading scripts (`GET /scripts`).                                  |
-| `scriptingPermissions.canSave`                      | `POST` / `PUT /scripts`.                                           |
-| `scriptingPermissions.canActivate`                  | Activate/deactivate scripts (`/scripts/:index/activate`).          |
-| `scriptingPermissions.canDelete`                    | Delete scripts (`DELETE /scripts/...`).                            |
-| `canUpdateTargetedPods`                             | Pod targeting endpoints (`/pods/target/...`).                      |
-| `canStopTrafficCapturing` / `canControlDissection`  | Dissection controls (`POST /settings/dissection`).                 |
-| `showAdminConsoleLink`                              | Frontend gate for the admin console link.                          |
-
-### Verifying the active role with `/whoami`
-
-`GET /whoami` returns the authenticated user's identity, resolved `authorizedActions`, and merged `authzFilters`. Useful for diagnosing "why don't I have access to X?" — the response shows exactly which roles the token claim returned (`user.roles`), which keys actually matched `auth.roles` (`user.effectiveRoles`), and the resulting permissions.
-
-The same data is surfaced in the dashboard as the **Identity & Access** modal — click your name in the top-right to open it. The modal shows the authenticated identity, claimed vs. effective roles, the per-action flag table, and the per-role namespace scope side-by-side, so non-admins can self-diagnose access without curl-ing `/whoami` directly.
+The same data is surfaced in the dashboard as the **Identity & Access** modal — click your name in the top-right to open it. The modal shows the authenticated identity, the resolved role, the capability list, and the namespace scope, so users can self-diagnose access without curl-ing `/whoami` directly.

--- a/src/pages/en/roles.md
+++ b/src/pages/en/roles.md
@@ -1,0 +1,154 @@
+---
+title: Roles & Permissions
+description: Built-in roles, capability vocabulary, group mapping, custom roles, and the license-side feature ceiling.
+layout: ../../layouts/MainLayout.astro
+mascot: Cute
+---
+
+Kubeshark's authorization model is composed of two layers that combine to produce a user's **effective capabilities**:
+
+1. **Role layer** — every authenticated user is resolved to one role. The role carries a set of capabilities (what UI surfaces and API endpoints they can use) and an optional namespace scope (which Kubernetes namespaces' traffic they can see).
+2. **License layer** — the license document carries a `Features` list that caps the capability set. Capabilities not unlocked by the current license are filtered out, regardless of role.
+
+The role configuration is shared across both [OIDC](/en/oidc) and [SAML](/en/saml) — admins maintain a single set of role definitions and switch identity backends without rewriting them.
+
+## Built-in roles
+
+Four built-in roles ship with Kubeshark. Their names and capability presets are immutable — operators can map SSO groups onto them but cannot rename them or change which capabilities they grant.
+
+| Role                  | Use case                                          | Live traffic | Snapshots tab | Settings / pod targeting |
+|-----------------------|---------------------------------------------------|--------------|---------------|--------------------------|
+| `kubeshark-admin`     | Full access — all capabilities, all namespaces.   | Read + control | Read + write + dissection | Yes |
+| `kubeshark-realtime`  | Live-focused. Watches live, toggles dissection, edits pod targeting + settings. **No snapshot tab.** | Read + control | Hidden | Yes |
+| `kubeshark-snapshot`  | Snapshot-focused. Creates / reads / deletes snapshots, runs delayed dissection. **No live access.** | Hidden | Read + write + dissection | No |
+| `kubeshark-viewer`    | Read-everything baseline. Watches live + browses snapshots. **No state changes.** | Read | Read | No |
+
+All four built-in roles are unscoped (`namespaces: "*"`). Namespace restrictions are an opt-in feature of custom roles only.
+
+## Capability vocabulary
+
+Capabilities are the atomic units of authorization. Each gated UI control and API endpoint is wired to exactly one capability.
+
+| Capability             | Gates                                                                                |
+|------------------------|--------------------------------------------------------------------------------------|
+| `dissection:control`   | Toggle live dissection on/off (`POST /settings/dissection`, UI Resume/Pause).        |
+| `dissection:live`      | Consume the live API stream (the dashboard's live traffic view).                     |
+| `pods:target:write`    | Edit the pod-targeting list (`POST /pods/target/*`).                                 |
+| `settings:write`       | Write the rest of the Settings dialog.                                               |
+| `snapshot:read`        | List / read snapshots, download PCAPs, view delayed-dissection results.              |
+| `snapshot:write`       | Create / delete / rename / upload snapshots.                                         |
+| `snapshot:dissection`  | Start / stop delayed-dissection job lifecycle.                                       |
+
+The vocabulary is closed: unknown capability strings in a custom role are dropped with a warning at hub startup (visible in `kubectl logs`).
+
+### Built-in role presets
+
+| Capability             | `admin` | `realtime` | `snapshot` | `viewer` |
+|------------------------|:-------:|:----------:|:----------:|:--------:|
+| `dissection:control`   |    ✓    |     ✓      |            |          |
+| `dissection:live`      |    ✓    |     ✓      |            |    ✓     |
+| `pods:target:write`    |    ✓    |     ✓      |            |          |
+| `settings:write`       |    ✓    |     ✓      |            |          |
+| `snapshot:read`        |    ✓    |            |     ✓      |    ✓     |
+| `snapshot:write`       |    ✓    |            |     ✓      |          |
+| `snapshot:dissection`  |    ✓    |            |     ✓      |          |
+
+## Mapping SSO groups to roles
+
+The `tap.auth.groupMapping` block translates SSO claim values (OIDC group names, SAML attribute values) into role names:
+
+```yaml
+tap:
+  auth:
+    groupMapping:
+      sso-engineering-leads: kubeshark-admin
+      sso-sre-oncall: kubeshark-realtime
+      sso-support: kubeshark-viewer
+      payments-team: payments-viewer    # custom role, see below
+```
+
+Built-in role names (`kubeshark-*`) can also be **identity-matched** — if a user's claim already contains the literal string `kubeshark-admin`, they resolve to admin without needing an explicit `groupMapping` entry. Identity-match is built-in-only: custom role names MUST appear in `groupMapping` to participate.
+
+When a user's claim resolves to multiple role candidates, the highest-precedence built-in wins (`admin > realtime > snapshot > viewer`). Built-in roles always rank above custom roles when both match.
+
+If no candidates remain, `tap.auth.defaultRole` is applied. The chart's default is `kubeshark-viewer`. Set `defaultRole: ""` for strict-deny — authenticated users with no recognized claim get no capabilities.
+
+## Custom roles
+
+Operators can declare custom roles under `tap.auth.roles` to grant a narrower capability set or to limit visibility to specific namespaces:
+
+```yaml
+tap:
+  auth:
+    groupMapping:
+      payments-team: payments-viewer
+      checkout-ops: checkout-ops
+    roles:
+      payments-viewer:
+        capabilities:
+          - snapshot:read
+        namespaces: "payments,checkout"
+      checkout-ops:
+        capabilities:
+          - snapshot:read
+          - snapshot:write
+          - snapshot:dissection
+        namespaces: "checkout"
+```
+
+### Rules
+
+- **Names with the `kubeshark-` prefix are reserved** for built-in roles and will be rejected at hub startup.
+- **Custom roles must be referenced from `groupMapping`** — identity-match doesn't apply to custom role names.
+- **Unknown capability strings** in `capabilities:` are dropped with a warning at hub startup.
+- **Built-in roles win over custom roles** when a user's claim matches both.
+
+### Namespace scope
+
+The `namespaces` field accepts a comma-separated list with `*` and glob support:
+
+| Value             | Effect                                                                              |
+|-------------------|-------------------------------------------------------------------------------------|
+| `""` (unset)      | Deny all — the user can authenticate but sees no traffic.                           |
+| `"*"`             | Every namespace; no scope filter applied.                                           |
+| `"foo"`           | Only the literal namespace `foo`.                                                   |
+| `"foo,bar"`       | OR over literal namespaces; whitespace tolerated.                                   |
+| `"foo-*"`         | Glob expansion against the cluster's currently-watched namespaces.                  |
+| `"a, b, c-*"`     | Mix of literals and globs in the same list.                                         |
+
+The hub expands the list into a server-side KFL filter (`src.namespace in {…} OR dst.namespace in {…}`) AND-ed onto every query and stream. Out-of-scope entries never leave the hub — enforcement covers REST queries, the legacy `/ws` stream, and the Connect-RPC dashboard stream.
+
+## License layer
+
+The license document carries an optional `Features` list. Each feature unlocks a group of capabilities:
+
+| Feature      | Unlocks                                                       |
+|--------------|---------------------------------------------------------------|
+| `realtime`   | `dissection:live`                                             |
+| `snapshot`   | `snapshot:read`, `snapshot:write`, `snapshot:dissection`      |
+
+Three deployment-admin capabilities are **always granted** regardless of the license: `dissection:control`, `settings:write`, `pods:target:write`. These gate cluster-admin actions, which are role-side concerns rather than commercial ones.
+
+### Enforcement rules
+
+- **`Features` field absent or `null`** (legacy licenses) — no enforcement; role preset applies as-is.
+- **`Features: []`** (explicit empty list) — no enforcement; role preset applies as-is. This is what the mint pipeline ships for every edition today.
+- **`Features: ["realtime"]`** — enforcement on; effective capabilities = role preset ∩ (realtime caps ∪ always-allowed caps).
+
+`/license` surfaces the active feature list and the resolved capability ceiling for inspection.
+
+## Authentication bypass paths
+
+Three code paths skip the role resolution entirely and grant the full `kubeshark-admin` capability set:
+
+- **Anonymous mode** (`tap.auth.enabled: false`) — every request runs as admin.
+- **License-Key header** — the in-cluster controller path used by Kubeshark's own tooling (CLI, MCP).
+- **InternalAuth bearer token** — the in-cluster controller path used by dissection-job pods.
+
+These bypasses ensure that AI agents on MCP and delayed-dissection jobs continue to function regardless of how restrictively the role config is set.
+
+## Verifying the active role
+
+`GET /whoami` returns the authenticated user's identity, resolved `role`, effective `capabilities`, and `authzFilters` (the KFL clauses derived from the role's namespace scope). Use it to diagnose access issues.
+
+The dashboard's **Identity & Access** modal — click your name in the top-right — shows the same information in a UI: identity, resolved role, capability list, namespace scope.

--- a/src/pages/en/saml.md
+++ b/src/pages/en/saml.md
@@ -6,57 +6,56 @@ mascot: Cute
 ---
 
 SAML integration provides:
-1. Authentication using corporate identities.
-2. Role-based feature accessibility (`authorizedActions`).
-3. Role-based traffic visibility (KFL filter applied to every query).
 
-The `roles` map and `rolesClaim` are **shared with OIDC** — see the [OIDC page](/en/oidc) for the same configuration applied against an OIDC identity provider.
+1. **Authentication** using corporate identities through your SAML IdP.
+2. **Role-based authorization** — every authenticated user is resolved to one of four built-in roles (or a custom role you define), which controls which UI surfaces and API endpoints they can use.
+3. **Namespace-scoped data visibility** — custom roles can be limited to a comma-separated list of Kubernetes namespaces; the hub injects a server-side filter so users only see traffic from their scope.
 
-### SAML Configuration Clause
+The role configuration (`tap.auth.roles`, `tap.auth.rolesClaim`, `tap.auth.groupMapping`, `tap.auth.defaultRole`) is **shared with OIDC** — see the [Roles & Permissions page](/en/roles) for the full vocabulary. The [OIDC page](/en/oidc) covers the same role model applied against an OIDC IdP.
+
+## SAML Configuration
 
 ```yaml
-auth:
-  enabled: true
-  type: saml
-  # SAML attribute carrying the user's role memberships.
-  # In the example IdP below this is named "users-roles"; it can be any
-  # attribute name the IdP exposes.
-  rolesClaim: role
-  # Optional: name of a role inside `roles` applied when an authenticated
-  # user has no matching role in their assertion. Empty = no fallback.
-  defaultRole: ""
-  roles:
-    admin:
-      # Comma-separated namespace list controlling traffic visibility:
-      #   ""        — deny all
-      #   "*"       — every namespace
-      #   "foo"     — single literal namespace
-      #   "foo,bar" — OR over literals
-      #   "foo-*"   — glob expansion against the cluster's known namespaces
-      namespaces: "*"
-      canDownloadPCAP: true
-      canUseScripting: true
-      scriptingPermissions:
-        canSave: true
-        canActivate: true
-        canDelete: true
-      canUpdateTargetedPods: true
-      canStopTrafficCapturing: true
-      canControlDissection: true
-      showAdminConsoleLink: true
-  saml:
-    idpMetadataUrl: ""
-    x509crt: ""
-    x509key: ""
+# values.yaml
+
+tap:
+  auth:
+    enabled: true
+    type: saml
+    # SAML attribute carrying the user's role memberships. In the
+    # example IdP below this is named `users-roles`; it can be any
+    # attribute name your IdP exposes.
+    rolesClaim: users-roles
+    # Built-in role applied when an authenticated user has no attribute
+    # value that maps to a role. Set to "" for strict-deny (authenticated
+    # but no capabilities). Default in the chart is `kubeshark-viewer`.
+    defaultRole: kubeshark-viewer
+    # Map SAML attribute values → role names. Names may reference one of
+    # the four built-in roles (kubeshark-admin / kubeshark-realtime /
+    # kubeshark-snapshot / kubeshark-viewer) or a custom role declared
+    # under `roles` below.
+    groupMapping:
+      engineering-leads: kubeshark-admin
+      sre-oncall: kubeshark-realtime
+      support: kubeshark-viewer
+      payments-team: payments-viewer    # custom role, see `roles` below
+    # Custom (operator-defined) roles. Each role declares its capability
+    # set + namespace scope. Names starting with `kubeshark-` are
+    # reserved for built-ins and will be rejected at hub startup.
+    roles:
+      payments-viewer:
+        capabilities:
+          - snapshot:read
+        namespaces: "payments,checkout"
+    saml:
+      idpMetadataUrl: ""
+      x509crt: ""
+      x509key: ""
 ```
 
-> **Breaking changes since the unified-roles rollout:**
-> - Legacy `auth.saml.roles` and `auth.saml.roleAttribute` are no longer read — move their values to the top-level `auth.roles` and `auth.rolesClaim`.
-> - Empty/unset `auth.roles` no longer grants all permissions; admins relying on that behaviour must either populate `auth.roles` explicitly or set `auth.defaultRole`.
-> - Per-role `filter` (raw KFL string) was replaced with `namespaces` (comma list, see below). Configs carrying `filter:` are ignored at unmarshal — migrate to `namespaces:`.
-> - `auth.defaultFilter` is removed. The deny-default semantic moves into per-role `namespaces: ""`; opt out for admin roles with `namespaces: "*"`.
+> Custom role names MUST appear in `groupMapping` to participate in resolution. Identity-match (attribute value === role name) only works for the four built-in `kubeshark-*` names.
 
-### X.509 Certificate & Key
+## X.509 Certificate & Key
 
 ```shell
 openssl genrsa -out mykey.key 2048
@@ -67,120 +66,76 @@ openssl x509 -signkey mykey.key -in mycsr.csr -req -days 365 -out mycert.crt
 - `mycert.crt` — use for `tap.auth.saml.x509crt`.
 - `mykey.key` — use for `tap.auth.saml.x509key`.
 
-### IdP Authorization Configuration
+## IdP Attribute Configuration
 
-`auth.rolesClaim` should match the name of the SAML attribute set in the App Metadata (`app_metadata`) section of the IdP — e.g. `role`, `roles`, or any attribute name the IdP emits. The value can be a single text value or an array of values (multi-role users).
+`tap.auth.rolesClaim` must match the name of the SAML attribute set in the App Metadata (`app_metadata`) section of the IdP — e.g. `role`, `roles`, `users-roles`, or any attribute name the IdP emits. The value can be a single text value or an array of values (multi-role users).
 
 For example, in [Auth0](https://auth0.com/) it looks like this:
 
 ![IdP App Metadata](/app_metadata.png)
 
-Each role key inside `auth.roles` is matched against the values returned in this attribute.
+Each attribute value is matched against `groupMapping` first, then identity-matched against built-in role names. See [Roles & Permissions](/en/roles) for the resolution algorithm.
 
-### Namespace Authorization Rules
+## Role Resolution
 
-Each role specifies a `namespaces` list that limits the Kubernetes namespaces whose traffic is visible to users in that role. The hub expands the list internally into a KFL filter (`src.pod.namespace.name=="…" || dst.pod.namespace.name=="…"`) AND-ed onto every query and stream. Enforcement covers all hub data paths: REST queries, the legacy `/ws` stream, and the Connect-RPC streaming endpoints used by the dashboard.
+When a user signs in, the hub walks the attribute values in this order:
 
-| Value | Effect |
-|---|---|
-| `""` (unset) | Deny all — explicit deny-default for the role. |
-| `"*"` | Every namespace; no scope filter applied. |
-| `"foo"` | Only the literal namespace `foo` (src or dst). |
-| `"foo,bar"` | OR over literal namespaces; whitespace tolerated. |
-| `"foo-*"` | Glob expansion against the cluster's currently-watched namespaces (e.g. `payments-api`, `payments-db`). Re-evaluated at each role-resolve, so newly-deployed namespaces matching the pattern become visible at the next sign-in / token refresh. |
-| `"a, b, c-*"` | Mix of literals and globs in the same list. |
+1. For each value, check `groupMapping`. If present, the mapped role becomes a candidate.
+2. Otherwise, if the value identity-matches a built-in role name (`kubeshark-admin`, `kubeshark-realtime`, `kubeshark-snapshot`, `kubeshark-viewer`), it becomes a candidate.
+3. Anything else is silently dropped.
+4. The highest-precedence built-in candidate wins (`admin > realtime > snapshot > viewer`). Built-in roles always rank above custom roles when both match.
+5. If no candidates remain, `defaultRole` is applied. If `defaultRole` is empty, the user is authenticated but has no capabilities (strict-deny).
 
-Users assigned to multiple roles see the union of every role's namespaces (logical OR). A role with `namespaces: "*"` lifts every restriction the user would otherwise carry from another role.
+See [Roles & Permissions](/en/roles) for the full algorithm, capability vocabulary, and namespace-scope semantics.
 
-### Feature Authorization Rules
+## Behaviour when the SAML session can't be resolved
 
-Each role's flags map to UI / API actions:
+If the hub fails to resolve a SAML session for a request — service provider not initialized, session cookie missing or expired, claims malformed — both action-level and data-level authorization fail closed:
 
-| Flag                                          | Gates                                                                   |
-|-----------------------------------------------|-------------------------------------------------------------------------|
-| `canDownloadPCAP`                             | PCAP download endpoints (`/pcaps/download/...`).                        |
-| `canUseScripting`                             | Reading scripts (`GET /scripts`).                                       |
-| `scriptingPermissions.canSave`                | `POST` / `PUT /scripts`.                                                |
-| `scriptingPermissions.canActivate`            | Activate/deactivate scripts (`/scripts/:index/activate`).               |
-| `scriptingPermissions.canDelete`              | Delete scripts (`DELETE /scripts/...`).                                 |
-| `canUpdateTargetedPods`                       | Pod targeting endpoints (`/pods/target/...`).                           |
-| `canStopTrafficCapturing` / `canControlDissection` | Dissection controls (`POST /settings/dissection`).                  |
-| `showAdminConsoleLink`                        | Frontend gate for the admin console link.                               |
+- The capability set is empty, so every gated UI action and API endpoint returns 403.
+- The data path injects a deny-all filter, so REST queries, the legacy WebSocket stream, and Connect-RPC dashboard streams all return empty for the failed request — not "everything in the cluster".
 
-### Behaviour when the SAML session can't be resolved
+If you see "no permission" alerts paired with an empty entries list, inspect `/whoami` first — `authenticated: false` (or an `authType: saml` response with no `user`) usually points at the SAML session, not the role config.
 
-If the hub fails to resolve a SAML session for a request — service provider not initialized, session cookie missing or expired, claims malformed, or the session-stored `authzActions` block is missing — both action-level and data-level RBAC fail closed:
-
-- `authorizedActions` is set to a deny-all (zero-value) action set, so every gated UI action returns 403.
-- `authzFilters` is published as an explicit deny-all KFL clause (`1==0`). The data path AND-s this into every query, so REST results, the legacy WebSocket stream, and Connect-RPC dashboard streams all return empty for the failed request, not "everything in the cluster."
-
-This closes a previous gap where a partially-broken SAML session would deny actions but leave the data path wide open. If you see "no permission" alerts paired with an empty entries list, inspect `/whoami` first — `authenticated: false` (or an `authType: saml` response with no `user`) usually points at the SAML session, not the role config.
-
-### Example
+## Example
 
 ```yaml
-auth:
-  enabled: true
-  type: saml
-  rolesClaim: users-roles
-  defaultRole: ""
-  roles:
-    developers:
-      namespaces: "ks-load"
-      canDownloadPCAP: false
-      canUseScripting: false
-      scriptingPermissions:
-        canSave: false
-        canActivate: false
-        canDelete: false
-      canUpdateTargetedPods: false
-    devops:
-      namespaces: "default"
-      canDownloadPCAP: true
-      canUseScripting: true
-      scriptingPermissions:
-        canSave: true
-        canActivate: true
-        canDelete: true
-      canUpdateTargetedPods: false
-    admins:
-      namespaces: "*"
-      canDownloadPCAP: true
-      canUseScripting: true
-      scriptingPermissions:
-        canSave: true
-        canActivate: true
-        canDelete: true
-      canUpdateTargetedPods: true
-      canStopTrafficCapturing: true
-      canControlDissection: true
-      showAdminConsoleLink: true
-  saml:
-    idpMetadataUrl: https://dev-....us.auth0.com/samlp/metadata/9K...pO
-    x509crt: |
-      -----BEGIN CERTIFICATE-----
-      MIIDgzCCAmsCFDtG4VpACGCxV9cAsa6Z+9dA3suWMA0GCSqGSIb3DQEBCwUAMH4x
-      ...
-      -----END CERTIFICATE-----
-    x509key: |
-      -----BEGIN PRIVATE KEY-----
-      MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCW6rSxwgOW5ZvY
-      ...
-      -----END PRIVATE KEY-----
+tap:
+  auth:
+    enabled: true
+    type: saml
+    rolesClaim: users-roles
+    defaultRole: kubeshark-viewer
+    groupMapping:
+      admins: kubeshark-admin
+      sre: kubeshark-realtime
+      support: kubeshark-viewer
+      payments-ops: payments-ops
+    roles:
+      payments-ops:
+        capabilities:
+          - snapshot:read
+          - snapshot:write
+          - snapshot:dissection
+        namespaces: "payments,checkout"
+    saml:
+      idpMetadataUrl: https://dev-....us.auth0.com/samlp/metadata/9K...pO
+      x509crt: |
+        -----BEGIN CERTIFICATE-----
+        MIIDgzCCAmsCFDtG4VpACGCxV9cAsa6Z+9dA3suWMA0GCSqGSIb3DQEBCwUAMH4x
+        ...
+        -----END CERTIFICATE-----
+      x509key: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCW6rSxwgOW5ZvY
+        ...
+        -----END PRIVATE KEY-----
 ```
 
-A user with the `app_metadata` below:
+A user with `users-roles: ["sre"]` resolves to `kubeshark-realtime` (live capture + dissection control, no snapshot tab). A user with `users-roles: ["payments-ops"]` resolves to the custom role and can manage snapshots only for the `payments` and `checkout` namespaces. A user with no recognized attribute value falls back to `kubeshark-viewer` (read-everything baseline).
 
-```yaml
-{
-  users-roles: [ "devops", "developers" ]
-}
-```
+## Verifying the active role with `/whoami`
 
-…sees traffic in both the `ks-load` and `default` namespaces and gets the `devops` action set (everything except `canUpdateTargetedPods`/dissection control). Only users with the `admins` role can change pod targeting or dissection settings.
+`GET /whoami` returns the authenticated user's identity, resolved `role`, effective `capabilities`, and any `authzFilters` derived from the role's namespace scope. Useful for diagnosing access issues — the response shows exactly which role was resolved and which capabilities are active.
 
-### Verifying the active role with `/whoami`
-
-`GET /whoami` returns the authenticated user's identity, resolved `authorizedActions`, and merged `authzFilters`. Useful for diagnosing "why don't I have access to X?" — the response shows exactly which roles the IdP returned (`user.roles`), which keys actually matched `auth.roles` (`user.effectiveRoles`), and the resulting permissions.
-
-The same data is surfaced in the dashboard as the **Identity & Access** modal — click your name in the top-right to open it. The modal shows the authenticated identity, claimed vs. effective roles, the per-action flag table, and the per-role namespace scope side-by-side, so non-admins can self-diagnose access without curl-ing `/whoami` directly.
+The same data is surfaced in the dashboard as the **Identity & Access** modal — click your name in the top-right to open it.


### PR DESCRIPTION
## Summary

Updates the user-facing OIDC, SAML, helm-reference, and nav documentation to describe the unified auth model that actually ships:

### New page: `roles.md`
Single canonical reference for the role model:
- Four built-in roles + their capability presets (admin / realtime / snapshot / viewer).
- Closed seven-entry capability vocabulary.
- `tap.auth.groupMapping` semantics + built-in identity-match.
- Custom roles under `tap.auth.roles` with `capabilities` + `namespaces`.
- Namespace-scope syntax (`""` deny, `"*"` allow-all, literals, globs).
- License Features ceiling (`realtime`, `snapshot`) + always-allowed deployment-admin caps.
- Authentication bypass paths (anonymous, License-Key, InternalAuth).
- `/whoami` + Identity & Access modal.

### Rewrites: `oidc.md`, `saml.md`
Drop the pre-refactor per-role action-flag examples (`canDownloadPCAP`, `scriptingPermissions`, etc.). Describe the new `tap.auth.{rolesClaim, defaultRole, groupMapping, roles}` shape. Both pages link to `roles.md` for the role model so they only cover their backend-specific config.

### Updates: `helm_reference.md`, `config.ts`
- Auth-reference table now reflects the new schema.
- Nav adds "Roles & Permissions" pointing to `roles.md`.

User-focused — covers what's needed to configure OIDC or SAML, not the internal design history.

## Test plan

- [ ] `npm run build` succeeds (Astro static build)
- [ ] Local preview renders `/en/roles`, `/en/oidc`, `/en/saml`, `/en/helm_reference` correctly
- [ ] All internal links resolve