### PR TITLE
Remove broken sidebar links for dissection pages

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -54,8 +54,6 @@ export const SIDEBAR: Sidebar = {
       { text: 'Raw Capture', link: 'en/v2/raw_capture' },
       { text: 'Traffic Snapshots', link: 'en/v2/traffic_snapshots' },
       { text: 'API (L7) Dissection', link: 'en/v2/l7_api_dissection' },
-      { text: 'Real-time Dissection', link: 'en/v2/l7_api_realtime' },
-      { text: 'Delayed Dissection', link: 'en/v2/l7_api_delayed' },
       { text: 'Protocol Support', link: 'en/protocols' },
       { text: 'AI-Driven Workflows', link: 'en/v2/ai_powered_analysis' },
       // { text: 'Running Headless', link: 'en/headless' },


### PR DESCRIPTION
## Summary
- Remove sidebar entries for `l7_api_realtime` and `l7_api_delayed` which point to non-existent pages (404s)
- Both topics (Real-time Indexing and Delayed Indexing) are already covered as sections within the `l7_api_dissection` page

## Test plan
- [ ] Verify no more 404s from sidebar navigation